### PR TITLE
Hotfix orderings

### DIFF
--- a/src/main/scala-2.11/markets/orders/orderings/AskPriceOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/AskPriceOrdering.scala
@@ -15,13 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.OrderLike
+import markets.orders.AskOrderLike
 
 
-trait PricePriority {
-
-  def hasPricePriority(order1: OrderLike, order2: OrderLike): Boolean = {
-    order1.price < order2.price
-  }
-
-}
+object AskPriceOrdering extends PriceOrdering[AskOrderLike] with AskPricePriority

--- a/src/main/scala-2.11/markets/orders/orderings/AskPricePriority.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/AskPricePriority.scala
@@ -1,0 +1,11 @@
+package markets.orders.orderings
+
+import markets.orders.AskOrderLike
+
+trait AskPricePriority extends {
+
+  def hasPricePriority(order1: AskOrderLike, order2: AskOrderLike): Boolean = {
+    order1.price < order2.price
+  }
+
+}

--- a/src/main/scala-2.11/markets/orders/orderings/AskPriceTimeOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/AskPriceTimeOrdering.scala
@@ -15,13 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.OrderLike
+import markets.orders.AskOrderLike
 
 
-trait TimePriority {
-
-  def hasTimePriority(order1: OrderLike, order2: OrderLike): Boolean = {
-    order1.timestamp < order2.timestamp
-  }
-
-}
+object AskPriceTimeOrdering extends PriceTimeOrdering[AskOrderLike] with AskPricePriority

--- a/src/main/scala-2.11/markets/orders/orderings/AskTimeOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/AskTimeOrdering.scala
@@ -15,22 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.OrderLike
+import markets.orders.AskOrderLike
 
 
-trait TimeOrdering[T <: OrderLike] extends Ordering[T] {
-
-  def compare(order1: T, order2: T): Int = {
-    if (hasTimePriority(order1, order2)) {
-      -1
-    } else {
-      1
-    }
-
-  }
-
-  def hasTimePriority(order1: T, order2: T): Boolean = {
-    order1.timestamp < order2.timestamp
-  }
-
-}
+object AskTimeOrdering extends TimeOrdering[AskOrderLike]

--- a/src/main/scala-2.11/markets/orders/orderings/BidPriceOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/BidPriceOrdering.scala
@@ -15,22 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.OrderLike
+import markets.orders.BidOrderLike
 
 
-trait TimeOrdering[T <: OrderLike] extends Ordering[T] {
-
-  def compare(order1: T, order2: T): Int = {
-    if (hasTimePriority(order1, order2)) {
-      -1
-    } else {
-      1
-    }
-
-  }
-
-  def hasTimePriority(order1: T, order2: T): Boolean = {
-    order1.timestamp < order2.timestamp
-  }
-
-}
+object BidPriceOrdering extends PriceOrdering[BidOrderLike] with BidPricePriority

--- a/src/main/scala-2.11/markets/orders/orderings/BidPricePriority.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/BidPricePriority.scala
@@ -1,0 +1,12 @@
+package markets.orders.orderings
+
+import markets.orders.BidOrderLike
+
+
+trait BidPricePriority extends {
+
+  def hasPricePriority(order1: BidOrderLike, order2: BidOrderLike): Boolean = {
+    order1.price > order2.price
+  }
+
+}

--- a/src/main/scala-2.11/markets/orders/orderings/BidPriceTimeOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/BidPriceTimeOrdering.scala
@@ -15,22 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.OrderLike
+import markets.orders.BidOrderLike
 
 
-trait TimeOrdering[T <: OrderLike] extends Ordering[T] {
-
-  def compare(order1: T, order2: T): Int = {
-    if (hasTimePriority(order1, order2)) {
-      -1
-    } else {
-      1
-    }
-
-  }
-
-  def hasTimePriority(order1: T, order2: T): Boolean = {
-    order1.timestamp < order2.timestamp
-  }
-
-}
+object BidPriceTimeOrdering extends PriceTimeOrdering[BidOrderLike] with BidPricePriority

--- a/src/main/scala-2.11/markets/orders/orderings/BidTimeOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/BidTimeOrdering.scala
@@ -15,22 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.OrderLike
+import markets.orders.BidOrderLike
 
 
-trait TimeOrdering[T <: OrderLike] extends Ordering[T] {
-
-  def compare(order1: T, order2: T): Int = {
-    if (hasTimePriority(order1, order2)) {
-      -1
-    } else {
-      1
-    }
-
-  }
-
-  def hasTimePriority(order1: T, order2: T): Boolean = {
-    order1.timestamp < order2.timestamp
-  }
-
-}
+object BidTimeOrdering extends TimeOrdering[BidOrderLike]

--- a/src/main/scala-2.11/markets/orders/orderings/PriceOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/PriceOrdering.scala
@@ -18,14 +18,16 @@ package markets.orders.orderings
 import markets.orders.OrderLike
 
 
-object PriceOrdering extends Ordering[OrderLike] with PricePriority {
+trait PriceOrdering[T <: OrderLike] extends Ordering[T] {
 
-  def compare(order1: OrderLike, order2: OrderLike): Int = {
+  def compare(order1: T, order2: T): Int = {
     if (hasPricePriority(order1, order2)) {
       -1
     } else {
       1
     }
   }
+
+  def hasPricePriority(order1: T, order2: T): Boolean
 
 }

--- a/src/main/scala-2.11/markets/orders/orderings/PriceTimeOrdering.scala
+++ b/src/main/scala-2.11/markets/orders/orderings/PriceTimeOrdering.scala
@@ -18,9 +18,9 @@ package markets.orders.orderings
 import markets.orders.OrderLike
 
 
-object PriceTimeOrdering extends Ordering[OrderLike] with PricePriority with TimePriority {
+trait PriceTimeOrdering[T <: OrderLike] extends PriceOrdering[T] with TimeOrdering[T] {
 
-  def compare(order1: OrderLike, order2: OrderLike): Int = {
+  override def compare(order1: T, order2: T): Int = {
     if (hasPricePriority(order1, order2)) {
       -1
     } else if (hasTimePriority(order1, order2)) {
@@ -31,7 +31,7 @@ object PriceTimeOrdering extends Ordering[OrderLike] with PricePriority with Tim
 
   }
 
-  override def hasTimePriority(order1: OrderLike, order2: OrderLike): Boolean = {
+  override def hasTimePriority(order1: T, order2: T): Boolean = {
     (order1.price == order2.price) && super.hasTimePriority(order1, order2)
   }
 

--- a/src/test/scala-2.11/markets/orders/orderings/AskPriceOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/AskPriceOrderingSpec.scala
@@ -66,7 +66,7 @@ class AskPriceOrderingSpec extends TestKit(ActorSystem("AskPriceOrderingSpec")) 
       When("an order arrives with a sufficiently low price, then this order should move to " +
         "the head of the book.")
 
-      // initial head of the order book
+      // initial state of the order book
       orderBook.toSeq should equal(Seq(lowPriceOrder, highPriceOrder))
 
       // simulate the arrival of a sufficiently low price order

--- a/src/test/scala-2.11/markets/orders/orderings/AskPriceTimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/AskPriceTimeOrderingSpec.scala
@@ -15,18 +15,17 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.{LimitAskOrder, LimitBidOrder, MarketAskOrder, MarketBidOrder, OrderLike}
-import markets.tradables.TestTradable
-import org.scalatest.{BeforeAndAfterAll, FeatureSpecLike, GivenWhenThen, Matchers}
-
-import scala.collection.mutable
 import scala.util.Random
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import markets.orders._
+import markets.tradables.TestTradable
+import org.scalatest.{BeforeAndAfterAll, FeatureSpecLike, GivenWhenThen, Matchers}
+import scala.collection.mutable
 
 
-class PriceOrderingSpec extends TestKit(ActorSystem("PriceOrderingSpec")) with
+class AskPriceTimeOrderingSpec extends TestKit(ActorSystem("AskPriceTimeOrderingSpec")) with
   FeatureSpecLike with
   GivenWhenThen with
   Matchers with
@@ -43,27 +42,28 @@ class PriceOrderingSpec extends TestKit(ActorSystem("PriceOrderingSpec")) with
 
   val testTradable: TestTradable = TestTradable("AAPL")
 
-  feature("An order book using PriceOrdering should sort orders low to high on price.") {
+  feature("An ask order book using AskPriceTimeOrdering should sort orders low to high on price. " +
+    "If two orders have the same price, then orders are sorted low to high using timestamp.") {
 
     val lower: Long = 1
     val upper: Long = Long.MaxValue
     val prng: Random = new Random()
 
-    scenario("A new order lands in an order book with existing orders.") {
+    scenario("A new order lands in an ask order book with existing orders.") {
 
-      Given("An order book that contains existing orders")
+      Given("An ask order book that contains existing orders")
 
       val highPrice = randomLong(prng, lower, upper)
       val lowPrice = randomLong(prng, lower, highPrice)
       val highPriceOrder = LimitAskOrder(testActor, highPrice, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
-      val lowPriceOrder = LimitBidOrder(testActor, lowPrice, randomLong(prng, lower, upper),
+      val lowPriceOrder = LimitAskOrder(testActor, lowPrice, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
-      val orderBook = mutable.TreeSet[OrderLike]()(PriceOrdering)
+      val orderBook = mutable.TreeSet[AskOrderLike]()(AskPriceTimeOrdering)
 
       orderBook +=(highPriceOrder, lowPriceOrder)
 
-      When("an order arrives with a sufficiently low price, then this order should move to " +
+      When("an ask order arrives with a sufficiently low price, then this order should move to " +
         "the head of the book.")
 
       // initial head of the order book
@@ -75,26 +75,39 @@ class PriceOrderingSpec extends TestKit(ActorSystem("PriceOrderingSpec")) with
       orderBook += lowestPriceOrder
       orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder))
 
-      When("an order arrives with a sufficiently high price, then this order should move to " +
+      When("an ask order arrives with a sufficiently high price, then this order should move to " +
         "the tail of the book.")
 
       // simulate arrival of a sufficiently high price order
-      val highestPriceOrder = MarketBidOrder(testActor, randomLong(prng, lower, upper),
+      val highestPrice = randomLong(prng, highPrice, upper)
+      val highestPriceOrder = LimitAskOrder(testActor, highestPrice, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
       orderBook += highestPriceOrder
       orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
         highestPriceOrder))
 
       When("an order arrives with the same price as another order already on the book, then " +
-        "preference is given to the existing order.")
+        "preference is given to the order with the earlier timestamp.")
 
       // simulate arrival of order with same price
       val samePrice = highPrice
-      val samePriceOrder = LimitBidOrder(testActor, samePrice, randomLong(prng, lower, upper),
-        randomLong(prng, lower, upper), testTradable)
-      orderBook += samePriceOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
-        samePriceOrder, highestPriceOrder))
+      val earlierTime = randomLong(prng, lower, highPriceOrder.timestamp)
+      val earlierOrder = LimitAskOrder(testActor, samePrice, randomLong(prng, lower, upper),
+        earlierTime, testTradable)
+      orderBook += earlierOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, earlierOrder,
+        highPriceOrder, highestPriceOrder))
+
+      When("an order arrives with the same price and timestamp as another order already on the" +
+        " book, then preference is given to the existing order.")
+
+      // simulate arrival of order with same price and timestamp
+      val sameTime = highPriceOrder.timestamp
+      val sameOrder = LimitAskOrder(testActor, samePrice, randomLong(prng, lower, upper),
+        sameTime, testTradable)
+      orderBook += sameOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, earlierOrder,
+        highPriceOrder, sameOrder, highestPriceOrder))
 
     }
   }

--- a/src/test/scala-2.11/markets/orders/orderings/AskPriceTimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/AskPriceTimeOrderingSpec.scala
@@ -66,7 +66,7 @@ class AskPriceTimeOrderingSpec extends TestKit(ActorSystem("AskPriceTimeOrdering
       When("an ask order arrives with a sufficiently low price, then this order should move to " +
         "the head of the book.")
 
-      // initial head of the order book
+      // initial state of the order book
       orderBook.toSeq should equal(Seq(lowPriceOrder, highPriceOrder))
 
       // simulate the arrival of a sufficiently low price order

--- a/src/test/scala-2.11/markets/orders/orderings/BidPriceOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/BidPriceOrderingSpec.scala
@@ -43,7 +43,7 @@ class BidPriceOrderingSpec extends TestKit(ActorSystem("BidPriceOrderingSpec")) 
 
   val testTradable: TestTradable = TestTradable("AAPL")
 
-  feature("An bid order book using BidPriceOrdering should sort orders low to high on price.") {
+  feature("An bid order book using BidPriceOrdering should sort orders high to low on price.") {
 
     val lower: Long = 1
     val upper: Long = Long.MaxValue
@@ -64,27 +64,27 @@ class BidPriceOrderingSpec extends TestKit(ActorSystem("BidPriceOrderingSpec")) 
       orderBook +=(highPriceOrder, lowPriceOrder)
 
       When("an order arrives with a sufficiently low price, then this order should move to " +
-        "the head of the book.")
-
-      // initial head of the order book
-      orderBook.toSeq should equal(Seq(lowPriceOrder, highPriceOrder))
-
-      // simulate the arrival of a sufficiently low price order
-      val lowestPriceOrder = MarketBidOrder(testActor, randomLong(prng, lower, upper),
-        randomLong(prng, lower, upper), testTradable)
-      orderBook += lowestPriceOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder))
-
-      When("an order arrives with a sufficiently high price, then this order should move to " +
         "the tail of the book.")
 
+      // initial head of the order book
+      orderBook.toSeq should equal(Seq(highPriceOrder, lowPriceOrder))
+
+      // simulate the arrival of a sufficiently low price order
+      val lowestPrice = randomLong(prng, lower, lowPrice)
+      val lowestPriceOrder = LimitBidOrder(testActor, lowestPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += lowestPriceOrder
+      orderBook.toSeq should equal(Seq(highPriceOrder, lowPriceOrder, lowestPriceOrder))
+
+      When("an order arrives with a sufficiently high price, then this order should move to " +
+        "the head of the book.")
+
       // simulate arrival of a sufficiently high price order
-      val highestPrice = randomLong(prng, highPrice, upper)
-      val highestPriceOrder = LimitBidOrder(testActor, highestPrice, randomLong(prng, lower, upper),
+      val highestPriceOrder = MarketBidOrder(testActor, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
       orderBook += highestPriceOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
-        highestPriceOrder))
+      orderBook.toSeq should equal(Seq(highestPriceOrder, highPriceOrder, lowPriceOrder,
+        lowestPriceOrder))
 
       When("an order arrives with the same price as another order already on the book, then " +
         "preference is given to the existing order.")
@@ -94,8 +94,8 @@ class BidPriceOrderingSpec extends TestKit(ActorSystem("BidPriceOrderingSpec")) 
       val samePriceOrder = LimitBidOrder(testActor, samePrice, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
       orderBook += samePriceOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
-        samePriceOrder, highestPriceOrder))
+      orderBook.toSeq should equal(Seq(highestPriceOrder, highPriceOrder,
+        samePriceOrder, lowPriceOrder, lowestPriceOrder))
 
     }
   }

--- a/src/test/scala-2.11/markets/orders/orderings/BidPriceOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/BidPriceOrderingSpec.scala
@@ -1,0 +1,102 @@
+/*
+Copyright 2015 David R. Pugh, J. Doyne Farmer, and Dan F. Tang
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package markets.orders.orderings
+
+import markets.orders.{LimitBidOrder, MarketBidOrder, BidOrderLike}
+import markets.tradables.TestTradable
+import org.scalatest.{BeforeAndAfterAll, FeatureSpecLike, GivenWhenThen, Matchers}
+
+import scala.collection.mutable
+import scala.util.Random
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+
+
+class BidPriceOrderingSpec extends TestKit(ActorSystem("BidPriceOrderingSpec")) with
+  FeatureSpecLike with
+  GivenWhenThen with
+  Matchers with
+  BeforeAndAfterAll {
+
+  /** Shutdown actor system when finished. */
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  def randomLong(prng: Random, lower: Long, upper: Long): Long = {
+    math.abs(prng.nextLong()) % (upper - lower) + lower
+  }
+
+  val testTradable: TestTradable = TestTradable("AAPL")
+
+  feature("An bid order book using BidPriceOrdering should sort orders low to high on price.") {
+
+    val lower: Long = 1
+    val upper: Long = Long.MaxValue
+    val prng: Random = new Random()
+
+    scenario("A new bid order lands in an bid order book with existing orders.") {
+
+      Given("An order book that contains existing orders")
+
+      val highPrice = randomLong(prng, lower, upper)
+      val lowPrice = randomLong(prng, lower, highPrice)
+      val highPriceOrder = LimitBidOrder(testActor, highPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      val lowPriceOrder = LimitBidOrder(testActor, lowPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      val orderBook = mutable.TreeSet[BidOrderLike]()(BidPriceOrdering)
+
+      orderBook +=(highPriceOrder, lowPriceOrder)
+
+      When("an order arrives with a sufficiently low price, then this order should move to " +
+        "the head of the book.")
+
+      // initial head of the order book
+      orderBook.toSeq should equal(Seq(lowPriceOrder, highPriceOrder))
+
+      // simulate the arrival of a sufficiently low price order
+      val lowestPriceOrder = MarketBidOrder(testActor, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += lowestPriceOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder))
+
+      When("an order arrives with a sufficiently high price, then this order should move to " +
+        "the tail of the book.")
+
+      // simulate arrival of a sufficiently high price order
+      val highestPrice = randomLong(prng, highPrice, upper)
+      val highestPriceOrder = LimitBidOrder(testActor, highestPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += highestPriceOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
+        highestPriceOrder))
+
+      When("an order arrives with the same price as another order already on the book, then " +
+        "preference is given to the existing order.")
+
+      // simulate arrival of order with same price
+      val samePrice = highPrice
+      val samePriceOrder = LimitBidOrder(testActor, samePrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += samePriceOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
+        samePriceOrder, highestPriceOrder))
+
+    }
+  }
+}

--- a/src/test/scala-2.11/markets/orders/orderings/BidPriceOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/BidPriceOrderingSpec.scala
@@ -66,7 +66,7 @@ class BidPriceOrderingSpec extends TestKit(ActorSystem("BidPriceOrderingSpec")) 
       When("an order arrives with a sufficiently low price, then this order should move to " +
         "the tail of the book.")
 
-      // initial head of the order book
+      // initial state of the order book
       orderBook.toSeq should equal(Seq(highPriceOrder, lowPriceOrder))
 
       // simulate the arrival of a sufficiently low price order

--- a/src/test/scala-2.11/markets/orders/orderings/BidPriceTimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/BidPriceTimeOrderingSpec.scala
@@ -1,0 +1,114 @@
+/*
+Copyright 2015 David R. Pugh, J. Doyne Farmer, and Dan F. Tang
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package markets.orders.orderings
+
+import scala.util.Random
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import markets.orders._
+import markets.tradables.TestTradable
+import org.scalatest.{BeforeAndAfterAll, FeatureSpecLike, GivenWhenThen, Matchers}
+import scala.collection.mutable
+
+
+class BidPriceTimeOrderingSpec extends TestKit(ActorSystem("AskPriceTimeOrderingSpec")) with
+  FeatureSpecLike with
+  GivenWhenThen with
+  Matchers with
+  BeforeAndAfterAll {
+
+  /** Shutdown actor system when finished. */
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  def randomLong(prng: Random, lower: Long, upper: Long): Long = {
+    math.abs(prng.nextLong()) % (upper - lower) + lower
+  }
+
+  val testTradable: TestTradable = TestTradable("AAPL")
+
+  feature("An ask order book using AskPriceTimeOrdering should sort orders low to high on price. " +
+    "If two orders have the same price, then orders are sorted low to high using timestamp.") {
+
+    val lower: Long = 1
+    val upper: Long = Long.MaxValue
+    val prng: Random = new Random()
+
+    scenario("A new order lands in an ask order book with existing orders.") {
+
+      Given("An ask order book that contains existing orders")
+
+      val highPrice = randomLong(prng, lower, upper)
+      val lowPrice = randomLong(prng, lower, highPrice)
+      val highPriceOrder = LimitAskOrder(testActor, highPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      val lowPriceOrder = LimitAskOrder(testActor, lowPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      val orderBook = mutable.TreeSet[AskOrderLike]()(AskPriceTimeOrdering)
+
+      orderBook +=(highPriceOrder, lowPriceOrder)
+
+      When("an ask order arrives with a sufficiently low price, then this order should move to " +
+        "the head of the book.")
+
+      // initial head of the order book
+      orderBook.toSeq should equal(Seq(lowPriceOrder, highPriceOrder))
+
+      // simulate the arrival of a sufficiently low price order
+      val lowestPriceOrder = MarketAskOrder(testActor, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += lowestPriceOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder))
+
+      When("an ask order arrives with a sufficiently high price, then this order should move to " +
+        "the tail of the book.")
+
+      // simulate arrival of a sufficiently high price order
+      val highestPrice = randomLong(prng, highPrice, upper)
+      val highestPriceOrder = LimitAskOrder(testActor, highestPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += highestPriceOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
+        highestPriceOrder))
+
+      When("an order arrives with the same price as another order already on the book, then " +
+        "preference is given to the order with the earlier timestamp.")
+
+      // simulate arrival of order with same price
+      val samePrice = highPrice
+      val earlierTime = randomLong(prng, lower, highPriceOrder.timestamp)
+      val earlierOrder = LimitAskOrder(testActor, samePrice, randomLong(prng, lower, upper),
+        earlierTime, testTradable)
+      orderBook += earlierOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, earlierOrder,
+        highPriceOrder, highestPriceOrder))
+
+      When("an order arrives with the same price and timestamp as another order already on the" +
+        " book, then preference is given to the existing order.")
+
+      // simulate arrival of order with same price and timestamp
+      val sameTime = highPriceOrder.timestamp
+      val sameOrder = LimitAskOrder(testActor, samePrice, randomLong(prng, lower, upper),
+        sameTime, testTradable)
+      orderBook += sameOrder
+      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, earlierOrder,
+        highPriceOrder, sameOrder, highestPriceOrder))
+
+    }
+  }
+}

--- a/src/test/scala-2.11/markets/orders/orderings/BidPriceTimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/BidPriceTimeOrderingSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.{BeforeAndAfterAll, FeatureSpecLike, GivenWhenThen, Matcher
 import scala.collection.mutable
 
 
-class BidPriceTimeOrderingSpec extends TestKit(ActorSystem("AskPriceTimeOrderingSpec")) with
+class BidPriceTimeOrderingSpec extends TestKit(ActorSystem("BidPriceTimeOrderingSpec")) with
   FeatureSpecLike with
   GivenWhenThen with
   Matchers with
@@ -42,49 +42,49 @@ class BidPriceTimeOrderingSpec extends TestKit(ActorSystem("AskPriceTimeOrdering
 
   val testTradable: TestTradable = TestTradable("AAPL")
 
-  feature("An ask order book using AskPriceTimeOrdering should sort orders low to high on price. " +
+  feature("An bid order book using BidPriceTimeOrdering should sort orders low to high on price. " +
     "If two orders have the same price, then orders are sorted low to high using timestamp.") {
 
     val lower: Long = 1
     val upper: Long = Long.MaxValue
     val prng: Random = new Random()
 
-    scenario("A new order lands in an ask order book with existing orders.") {
+    scenario("A new order lands in an bid order book with existing orders.") {
 
-      Given("An ask order book that contains existing orders")
+      Given("An bid order book that contains existing orders")
 
       val highPrice = randomLong(prng, lower, upper)
       val lowPrice = randomLong(prng, lower, highPrice)
-      val highPriceOrder = LimitAskOrder(testActor, highPrice, randomLong(prng, lower, upper),
+      val highPriceOrder = LimitBidOrder(testActor, highPrice, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
-      val lowPriceOrder = LimitAskOrder(testActor, lowPrice, randomLong(prng, lower, upper),
+      val lowPriceOrder = LimitBidOrder(testActor, lowPrice, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
-      val orderBook = mutable.TreeSet[AskOrderLike]()(AskPriceTimeOrdering)
+      val orderBook = mutable.TreeSet[BidOrderLike]()(BidPriceTimeOrdering)
 
       orderBook +=(highPriceOrder, lowPriceOrder)
 
-      When("an ask order arrives with a sufficiently low price, then this order should move to " +
+      When("an bid order arrives with a sufficiently high price, then this order should move to " +
         "the head of the book.")
 
       // initial head of the order book
-      orderBook.toSeq should equal(Seq(lowPriceOrder, highPriceOrder))
+      orderBook.toSeq should equal(Seq(highPriceOrder, lowPriceOrder))
 
-      // simulate the arrival of a sufficiently low price order
-      val lowestPriceOrder = MarketAskOrder(testActor, randomLong(prng, lower, upper),
-        randomLong(prng, lower, upper), testTradable)
-      orderBook += lowestPriceOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder))
-
-      When("an ask order arrives with a sufficiently high price, then this order should move to " +
-        "the tail of the book.")
-
-      // simulate arrival of a sufficiently high price order
-      val highestPrice = randomLong(prng, highPrice, upper)
-      val highestPriceOrder = LimitAskOrder(testActor, highestPrice, randomLong(prng, lower, upper),
+      // simulate the arrival of a sufficiently high price order
+      val highestPriceOrder = MarketBidOrder(testActor, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), testTradable)
       orderBook += highestPriceOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, highPriceOrder,
-        highestPriceOrder))
+      orderBook.toSeq should equal(Seq(highestPriceOrder, highPriceOrder, lowPriceOrder))
+
+      When("an bid order arrives with a sufficiently low price, then this order should move to " +
+        "the tail of the book.")
+
+      // simulate arrival of a sufficiently low price order
+      val lowestPrice = randomLong(prng, lower, lowPrice)
+      val lowestPriceOrder = LimitBidOrder(testActor, lowestPrice, randomLong(prng, lower, upper),
+        randomLong(prng, lower, upper), testTradable)
+      orderBook += lowestPriceOrder
+      orderBook.toSeq should equal(Seq(highestPriceOrder, highPriceOrder, lowPriceOrder,
+        lowestPriceOrder))
 
       When("an order arrives with the same price as another order already on the book, then " +
         "preference is given to the order with the earlier timestamp.")
@@ -92,22 +92,22 @@ class BidPriceTimeOrderingSpec extends TestKit(ActorSystem("AskPriceTimeOrdering
       // simulate arrival of order with same price
       val samePrice = highPrice
       val earlierTime = randomLong(prng, lower, highPriceOrder.timestamp)
-      val earlierOrder = LimitAskOrder(testActor, samePrice, randomLong(prng, lower, upper),
+      val earlierOrder = LimitBidOrder(testActor, samePrice, randomLong(prng, lower, upper),
         earlierTime, testTradable)
       orderBook += earlierOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, earlierOrder,
-        highPriceOrder, highestPriceOrder))
+      orderBook.toSeq should equal(Seq(highestPriceOrder, earlierOrder, highPriceOrder,
+        lowPriceOrder, lowestPriceOrder))
 
       When("an order arrives with the same price and timestamp as another order already on the" +
         " book, then preference is given to the existing order.")
 
       // simulate arrival of order with same price and timestamp
       val sameTime = highPriceOrder.timestamp
-      val sameOrder = LimitAskOrder(testActor, samePrice, randomLong(prng, lower, upper),
+      val sameOrder = LimitBidOrder(testActor, samePrice, randomLong(prng, lower, upper),
         sameTime, testTradable)
       orderBook += sameOrder
-      orderBook.toSeq should equal(Seq(lowestPriceOrder, lowPriceOrder, earlierOrder,
-        highPriceOrder, sameOrder, highestPriceOrder))
+      orderBook.toSeq should equal(Seq(highestPriceOrder, earlierOrder, highPriceOrder,
+        sameOrder, lowPriceOrder, lowestPriceOrder))
 
     }
   }

--- a/src/test/scala-2.11/markets/orders/orderings/BidPriceTimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/BidPriceTimeOrderingSpec.scala
@@ -66,7 +66,7 @@ class BidPriceTimeOrderingSpec extends TestKit(ActorSystem("BidPriceTimeOrdering
       When("an bid order arrives with a sufficiently high price, then this order should move to " +
         "the head of the book.")
 
-      // initial head of the order book
+      // initial state of the order book
       orderBook.toSeq should equal(Seq(highPriceOrder, lowPriceOrder))
 
       // simulate the arrival of a sufficiently high price order

--- a/src/test/scala-2.11/markets/orders/orderings/TimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/TimeOrderingSpec.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package markets.orders.orderings
 
-import markets.orders.{MarketAskOrder, MarketBidOrder, OrderLike, LimitBidOrder, LimitAskOrder}
+import markets.orders.{MarketAskOrder, MarketBidOrder, AskOrderLike, LimitBidOrder, LimitAskOrder}
 import markets.tradables.TestTradable
 import org.scalatest.{FeatureSpecLike, Matchers, BeforeAndAfterAll, GivenWhenThen}
 
@@ -57,9 +57,9 @@ class TimeOrderingSpec extends TestKit(ActorSystem("TimeOrderingSpec")) with
       val earlyTime = randomLong(prng, lower, lateTime)
       val lateOrder = LimitAskOrder(testActor, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), lateTime, testTradable)
-      val earlyOrder = LimitBidOrder(testActor, randomLong(prng, lower, upper),
+      val earlyOrder = LimitAskOrder(testActor, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), earlyTime, testTradable)
-      val orderBook = mutable.TreeSet[OrderLike]()(TimeOrdering)
+      val orderBook = mutable.TreeSet[AskOrderLike]()(AskTimeOrdering)
 
       orderBook +=(lateOrder, earlyOrder)
 
@@ -71,7 +71,7 @@ class TimeOrderingSpec extends TestKit(ActorSystem("TimeOrderingSpec")) with
 
       // simulate the arrival of a sufficiently early order
       val earlierTime = randomLong(prng, lower, earlyTime)
-      val earlierOrder = MarketBidOrder(testActor, randomLong(prng, lower, upper), earlierTime,
+      val earlierOrder = MarketAskOrder(testActor, randomLong(prng, lower, upper), earlierTime,
         testTradable)
       orderBook += earlierOrder
       orderBook.toSeq should equal(Seq(earlierOrder, earlyOrder, lateOrder))
@@ -91,7 +91,7 @@ class TimeOrderingSpec extends TestKit(ActorSystem("TimeOrderingSpec")) with
 
       // simulate "simultaneous arrival" of orders
       val sameTime = lateTime
-      val sameTimeOrder = LimitBidOrder(testActor, randomLong(prng, lower, upper),
+      val sameTimeOrder = LimitAskOrder(testActor, randomLong(prng, lower, upper),
         randomLong(prng, lower, upper), sameTime, testTradable)
       orderBook += sameTimeOrder
       orderBook.toSeq should equal(Seq(earlierOrder, earlyOrder, lateOrder, sameTimeOrder,

--- a/src/test/scala-2.11/markets/orders/orderings/TimeOrderingSpec.scala
+++ b/src/test/scala-2.11/markets/orders/orderings/TimeOrderingSpec.scala
@@ -66,7 +66,7 @@ class TimeOrderingSpec extends TestKit(ActorSystem("TimeOrderingSpec")) with
       When("an order arrives with a sufficiently early timestamp, then this order should move to " +
         "the head of the book.")
 
-      // initial head of the order book
+      // initial state of the order book
       orderBook.toSeq should equal(Seq(earlyOrder, lateOrder))
 
       // simulate the arrival of a sufficiently early order


### PR DESCRIPTION
This PR undoes, fixes, and then extends a previous PR (i.e, #33) made in error.  Storing both ask and bid orders in the same order book was ill conceived. When books become uncrossed the principle "invariant" (i.e., head of book is best ask order and tail of book is best bid order) is violated.
