### PR TITLE
Refactored ContractLike trait.

### DIFF
--- a/src/main/scala-2.11/markets/clearing/engines/ContinuousDoubleAuctionLike.scala
+++ b/src/main/scala-2.11/markets/clearing/engines/ContinuousDoubleAuctionLike.scala
@@ -58,23 +58,22 @@ trait ContinuousDoubleAuctionLike extends MatchingEngineLike {
         case Some(bid) if bid.price >= ask.price =>
           bidOrderBook = bidOrderBook.tail  // removes bid from bidOrderBook! SIDE EFFECT!
           val excessDemand = bid.quantity - ask.quantity
-          val counterParties = (ask.issuer, bid.issuer)
           val price = formPrice(ask, bid)
           referencePrice = price  // SIDE EFFECT!
           if (excessDemand > 0) {
             val quantity = ask.quantity  // no rationing for incoming ask
-            val filledOrder = TotalFilledOrder(counterParties, price, quantity, 1, bid.tradable)
+            val filledOrder = TotalFilledOrder(ask.issuer, bid.issuer, price, quantity, 1, bid.tradable)
             // add residualBidOrder back into bidOrderBook! SIDE EFFECT!
             val residualBidOrder = bid.split(excessDemand)
             bidOrderBook = bidOrderBook ++ immutable.Iterable(residualBidOrder)
             accum.enqueue(filledOrder)
           } else if (excessDemand == 0) {  // ask quantity matches bid quantity
           val quantity = ask.quantity // no rationing for incoming ask!
-          val filledOrder = TotalFilledOrder(counterParties, price, quantity, 1, bid.tradable)
+          val filledOrder = TotalFilledOrder(ask.issuer, bid.issuer, price, quantity, 1, bid.tradable)
             accum.enqueue(filledOrder)
           } else {  // incoming ask is larger than bid and will be rationed!
           val quantity = bid.quantity  // rationing!
-          val filledOrder = PartialFilledOrder(counterParties, price, quantity, 1, bid.tradable)
+          val filledOrder = PartialFilledOrder(ask.issuer, bid.issuer, price, quantity, 1, bid.tradable)
             val residualAskOrder = ask.split(-excessDemand)
             accumulateFilledOrders(residualAskOrder, accum.enqueue(filledOrder))
           }
@@ -105,23 +104,22 @@ trait ContinuousDoubleAuctionLike extends MatchingEngineLike {
         case Some(ask) if bid.price >= ask.price =>
           askOrderBook = askOrderBook.tail // removes ask from askOrderBook! SIDE EFFECT!
           val excessDemand = bid.quantity - ask.quantity
-          val counterParties = (ask.issuer, bid.issuer)
           val price = formPrice(bid, ask)
           referencePrice = price  // SIDE EFFECT!
           if (excessDemand < 0) {
           val quantity = bid.quantity  // no rationing for incoming bid
-          val filledOrder = TotalFilledOrder(counterParties, price, quantity, 1, bid.tradable)
+          val filledOrder = TotalFilledOrder(bid.issuer, ask.issuer, price, quantity, 1, bid.tradable)
             // add residualAskOrder back into askOrderBook! SIDE EFFECT!
             val residualAskOrder = ask.split(-excessDemand)
             askOrderBook = askOrderBook ++ immutable.Iterable(residualAskOrder)
             accum.enqueue(filledOrder)
           } else if (excessDemand == 0) {  // bid quantity matches ask quantity
           val quantity = bid.quantity // no rationing for incoming bid!
-          val filledOrder = TotalFilledOrder(counterParties, price, quantity, 1, bid.tradable)
+          val filledOrder = TotalFilledOrder(bid.issuer, ask.issuer, price, quantity, 1, bid.tradable)
             accum.enqueue(filledOrder)
           } else {
           val quantity = ask.quantity  // incoming bid is rationed!
-          val filledOrder = PartialFilledOrder(counterParties, price, quantity, 1, bid.tradable)
+          val filledOrder = PartialFilledOrder(bid.issuer, ask.issuer, price, quantity, 1, bid.tradable)
             val residualBidOrder = bid.split(excessDemand)
             accumulateFilledOrders(residualBidOrder, accum.enqueue(filledOrder))
           }

--- a/src/main/scala-2.11/markets/orders/OrderLike.scala
+++ b/src/main/scala-2.11/markets/orders/OrderLike.scala
@@ -23,7 +23,7 @@ import markets.tradables.Tradable
 
 trait OrderLike extends ContractLike {
 
-  def issuer: ActorRef
+  val counterparty: Option[ActorRef] = None
 
   def price: Long
 

--- a/src/main/scala-2.11/markets/orders/filled/FilledOrderLike.scala
+++ b/src/main/scala-2.11/markets/orders/filled/FilledOrderLike.scala
@@ -15,15 +15,11 @@ limitations under the License.
 */
 package markets.orders.filled
 
-import akka.actor.ActorRef
-
-import markets.MessageLike
+import markets.ContractLike
 import markets.tradables.Tradable
 
 
-trait FilledOrderLike extends MessageLike {
-
-  def counterParties: (ActorRef, ActorRef)
+trait FilledOrderLike extends ContractLike {
 
   def tradable: Tradable
 

--- a/src/main/scala-2.11/markets/orders/filled/PartialFilledOrder.scala
+++ b/src/main/scala-2.11/markets/orders/filled/PartialFilledOrder.scala
@@ -20,8 +20,23 @@ import akka.actor.ActorRef
 import markets.tradables.Tradable
 
 
-case class PartialFilledOrder(counterParties: (ActorRef, ActorRef),
+case class PartialFilledOrder(counterparty: Option[ActorRef],
+                              issuer: ActorRef,
                               price: Long,
                               quantity: Long,
                               timestamp: Long,
                               tradable: Tradable) extends FilledOrderLike
+
+
+object PartialFilledOrder {
+
+  def apply(counterparty: ActorRef,
+            issuer: ActorRef,
+            price: Long,
+            quantity: Long,
+            timestamp: Long,
+            tradable: Tradable): PartialFilledOrder = {
+    new PartialFilledOrder(Some(counterparty), issuer, price, quantity, timestamp, tradable)
+  }
+
+}

--- a/src/main/scala-2.11/markets/orders/filled/TotalFilledOrder.scala
+++ b/src/main/scala-2.11/markets/orders/filled/TotalFilledOrder.scala
@@ -20,8 +20,23 @@ import akka.actor.ActorRef
 import markets.tradables.Tradable
 
 
-case class TotalFilledOrder(counterParties: (ActorRef, ActorRef),
+case class TotalFilledOrder(counterparty: Option[ActorRef],
+                            issuer: ActorRef,
                             price: Long,
                             quantity: Long,
                             timestamp: Long,
                             tradable: Tradable) extends FilledOrderLike
+
+
+object TotalFilledOrder {
+
+  def apply(counterparty: ActorRef,
+            issuer: ActorRef,
+            price: Long,
+            quantity: Long,
+            timestamp: Long,
+            tradable: Tradable): TotalFilledOrder = {
+    new TotalFilledOrder(Some(counterparty), issuer, price, quantity, timestamp, tradable)
+  }
+
+}

--- a/src/main/scala-2.11/markets/package.scala
+++ b/src/main/scala-2.11/markets/package.scala
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import akka.actor.ActorRef
+
+
 package object markets {
 
   /** Base trait for all messages. */
@@ -24,7 +27,15 @@ package object markets {
 
 
   /** Base trait for representing contracts. */
-  trait ContractLike extends MessageLike
+  trait ContractLike extends MessageLike {
+
+    /** The actor for whom the `ContractLike` is a liability. */
+    def issuer: ActorRef
+
+    /** The actor for whom the `ContractLike` is an asset. */
+    def counterparty: Option[ActorRef]
+
+  }
 
 
   case class OrderAccepted(timestamp: Long) extends MessageLike


### PR DESCRIPTION
This PR refactors the `ContractLike` trait to look more like an actual bilateral contract with a defined `issuer` and an optional  `counterparty`.  The `OrderLike` and `FilledOrderLike` traits should now be thought of as "just" additional types of contracts.  Markets are now best thought of as functions that take contracts as inputs and return contracts as outputs.
