### PR TITLE
Hotfix for MarketParticipantLike.

### DIFF
--- a/src/main/scala-2.11/markets/participants/MarketParticipantLike.scala
+++ b/src/main/scala-2.11/markets/participants/MarketParticipantLike.scala
@@ -17,8 +17,7 @@ package markets.participants
 
 import akka.actor.ActorRef
 
-import java.util.UUID
-
+import markets.orders.Order
 import markets.{Accepted, Add, BaseActor, Canceled, Rejected, Remove}
 import markets.tradables.Tradable
 
@@ -30,13 +29,13 @@ trait MarketParticipantLike {
 
   protected var markets: immutable.Map[Tradable, ActorRef]
 
-  protected var outstandingOrders: immutable.Set[UUID]
+  protected var outstandingOrders: immutable.Set[Order]
 
   def marketParticipantBehavior: Receive = {
     case Accepted(order, _, _) =>
-      outstandingOrders += order.uuid
+      outstandingOrders += order
     case Canceled(order, _, _) =>
-      outstandingOrders -= order.uuid
+      outstandingOrders -= order
     case Add(market, _, tradable, _) =>
       markets = markets + ((tradable, market))
     case Remove(_, _, tradable, _) =>

--- a/src/test/scala-2.11/markets/participants/MarketParticipantLikeSpec.scala
+++ b/src/test/scala-2.11/markets/participants/MarketParticipantLikeSpec.scala
@@ -62,7 +62,7 @@ class MarketParticipantLikeSpec extends TestKit(ActorSystem("MarketParticipantLi
 
       Then("...it should add the accepted orders UUID to its outstanding orders.")
       val marketParticipantActor = marketParticipant.underlyingActor
-      marketParticipantActor.outstandingOrders.headOption should be(Some(order.uuid))
+      marketParticipantActor.outstandingOrders.headOption should be(Some(order))
 
     }
 

--- a/src/test/scala-2.11/markets/participants/TestMarketParticipant.scala
+++ b/src/test/scala-2.11/markets/participants/TestMarketParticipant.scala
@@ -17,9 +17,8 @@ package markets.participants
 
 import akka.actor.ActorRef
 
-import java.util.UUID
-
 import markets.BaseActor
+import markets.orders.Order
 import markets.tradables.Tradable
 
 import scala.collection.immutable
@@ -29,7 +28,7 @@ class TestMarketParticipant extends BaseActor with MarketParticipantLike {
 
   var markets = immutable.Map.empty[Tradable, ActorRef]
 
-  var outstandingOrders = immutable.Set.empty[UUID]
+  var outstandingOrders = immutable.Set.empty[Order]
 
   def receive: Receive = {
     marketParticipantBehavior orElse baseActorBehavior


### PR DESCRIPTION
Now market participant stores orders and not just their UUIDs.
