### PR TITLE
Now split returns a tuple.

### DIFF
--- a/src/main/scala-2.11/markets/clearing/engines/CDAMatchingEngine.scala
+++ b/src/main/scala-2.11/markets/clearing/engines/CDAMatchingEngine.scala
@@ -86,7 +86,7 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
         if (residualQuantity < 0) {
           val totalMatch = TotalMatch(askOrder, incoming, price)
           // add residualOrder back into orderBook!
-          val residualOrder = askOrder.split(-residualQuantity)
+          val (_, residualOrder) = askOrder.split(-residualQuantity)
           _askOrderBook.add(residualOrder)  // SIDE EFFECT!
           matches.enqueue(totalMatch)
         } else if (residualQuantity == 0) {  // no rationing for incoming order!
@@ -94,7 +94,7 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
           matches.enqueue(totalMatch)
         } else {  // incoming order is larger than existing order and will be rationed!
           val partialMatch = PartialMatch(askOrder, incoming, price)
-          val residualOrder = incoming.split(residualQuantity)
+          val (_, residualOrder) = incoming.split(residualQuantity)
           accumulateAskOrders(residualOrder, matches.enqueue(partialMatch))
         }
 
@@ -117,7 +117,7 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
         if (residualQuantity < 0) {
           val totalMatch = TotalMatch(bidOrder, incoming, price)
           // add residualOrder back into orderBook!
-          val residualOrder = bidOrder.split(-residualQuantity)
+          val (_, residualOrder) = bidOrder.split(-residualQuantity)
           _bidOrderBook.add(residualOrder)  // SIDE EFFECT!
           matches.enqueue(totalMatch)
         } else if (residualQuantity == 0) {  // no rationing for incoming order!
@@ -125,7 +125,7 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
           matches.enqueue(totalMatch)
         } else {  // incoming order is larger than existing order and will be rationed!
           val partialMatch = PartialMatch(bidOrder, incoming, price)
-          val residualOrder = incoming.split(residualQuantity)
+          val (_, residualOrder) = incoming.split(residualQuantity)
           accumulateBidOrders(residualOrder, matches.enqueue(partialMatch))
         }
       case _ => // existingOrders is empty or incoming order does not cross best existing order.

--- a/src/main/scala-2.11/markets/clearing/engines/CDAMatchingEngine.scala
+++ b/src/main/scala-2.11/markets/clearing/engines/CDAMatchingEngine.scala
@@ -83,18 +83,17 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
         val residualQuantity = incoming.quantity - askOrder.quantity
         val price = formPrice(incoming, askOrder)
 
-        if (residualQuantity < 0) {
-          val totalMatch = TotalMatch(askOrder, incoming, price)
-          // add residualOrder back into orderBook!
-          val (_, residualOrder) = askOrder.split(-residualQuantity)
+        if (residualQuantity < 0) {  // incoming order is smaller than existing order
+          val (filledOrder, residualOrder) = askOrder.split(-residualQuantity)
+          val totalMatch = TotalMatch(filledOrder, incoming, price)
           _askOrderBook.add(residualOrder)  // SIDE EFFECT!
           matches.enqueue(totalMatch)
         } else if (residualQuantity == 0) {  // no rationing for incoming order!
           val totalMatch = TotalMatch(askOrder, incoming, price)
           matches.enqueue(totalMatch)
         } else {  // incoming order is larger than existing order and will be rationed!
-          val partialMatch = PartialMatch(askOrder, incoming, price)
-          val (_, residualOrder) = incoming.split(residualQuantity)
+          val (filledOrder, residualOrder) = incoming.split(residualQuantity)
+          val partialMatch = PartialMatch(askOrder, filledOrder, price)
           accumulateAskOrders(residualOrder, matches.enqueue(partialMatch))
         }
 
@@ -114,18 +113,17 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
         val residualQuantity = incoming.quantity - bidOrder.quantity
         val price = formPrice(incoming, bidOrder)
 
-        if (residualQuantity < 0) {
-          val totalMatch = TotalMatch(bidOrder, incoming, price)
-          // add residualOrder back into orderBook!
-          val (_, residualOrder) = bidOrder.split(-residualQuantity)
+        if (residualQuantity < 0) { // incoming order is smaller than existing order!
+          val (filledOrder, residualOrder) = bidOrder.split(-residualQuantity)
+          val totalMatch = TotalMatch(filledOrder, incoming, price)
           _bidOrderBook.add(residualOrder)  // SIDE EFFECT!
           matches.enqueue(totalMatch)
         } else if (residualQuantity == 0) {  // no rationing for incoming order!
           val totalMatch = TotalMatch(bidOrder, incoming, price)
           matches.enqueue(totalMatch)
         } else {  // incoming order is larger than existing order and will be rationed!
-          val partialMatch = PartialMatch(bidOrder, incoming, price)
-          val (_, residualOrder) = incoming.split(residualQuantity)
+          val (filledOrder, residualOrder) = incoming.split(residualQuantity)
+          val partialMatch = PartialMatch(bidOrder, filledOrder, price)
           accumulateBidOrders(residualOrder, matches.enqueue(partialMatch))
         }
       case _ => // existingOrders is empty or incoming order does not cross best existing order.

--- a/src/main/scala-2.11/markets/orders/AskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/AskOrder.scala
@@ -24,7 +24,11 @@ package markets.orders
   */
 trait AskOrder extends Order {
 
-  /** Orders will often need to be split during the matching process. */
+  /** Splits an existing `AskOrder` into two separate orders.
+    *
+    * @param residualQuantity
+    * @return a tuple of ask orders.
+    */
   def split(residualQuantity: Long): (AskOrder, AskOrder)
 
 }

--- a/src/main/scala-2.11/markets/orders/AskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/AskOrder.scala
@@ -25,6 +25,6 @@ package markets.orders
 trait AskOrder extends Order {
 
   /** Orders will often need to be split during the matching process. */
-  def split(newQuantity: Long): AskOrder
+  def split(residualQuantity: Long): (AskOrder, AskOrder)
 
 }

--- a/src/main/scala-2.11/markets/orders/BidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/BidOrder.scala
@@ -25,7 +25,7 @@ package markets.orders
 trait BidOrder extends Order {
 
   /** Orders will often need to be split during the matching process. */
-  def split(newQuantity: Long): BidOrder
+  def split(residualQuantity: Long): (BidOrder, BidOrder)
 
 }
 

--- a/src/main/scala-2.11/markets/orders/BidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/BidOrder.scala
@@ -24,8 +24,11 @@ package markets.orders
   */
 trait BidOrder extends Order {
 
-  /** Orders will often need to be split during the matching process. */
-  def split(residualQuantity: Long): (BidOrder, BidOrder)
+  /** Splits an existing `BidOrder` into two separate orders.
+    *
+    * @param residualQuantity
+    * @return a tuple of bid orders.
+    */  def split(residualQuantity: Long): (BidOrder, BidOrder)
 
 }
 

--- a/src/main/scala-2.11/markets/orders/limit/LimitAskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/limit/LimitAskOrder.scala
@@ -30,8 +30,9 @@ case class LimitAskOrder(issuer: ActorRef,
                          tradable: Tradable,
                          uuid: UUID) extends LimitOrderLike with AskOrder {
 
-  def split(newQuantity: Long): LimitAskOrder = {
-    LimitAskOrder(issuer, price, newQuantity, timestamp, tradable, uuid)
+  def split(residualQuantity: Long): (LimitAskOrder, LimitAskOrder) = {
+    val filledQuantity = quantity - residualQuantity
+    (this.copy(quantity = filledQuantity), this.copy(quantity = residualQuantity))
   }
 
 }

--- a/src/main/scala-2.11/markets/orders/limit/LimitBidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/limit/LimitBidOrder.scala
@@ -30,8 +30,9 @@ case class LimitBidOrder(issuer: ActorRef,
                          tradable: Tradable,
                          uuid: UUID) extends LimitOrderLike with BidOrder {
 
-  def split(newQuantity: Long): LimitBidOrder = {
-    LimitBidOrder(issuer, price, newQuantity, timestamp, tradable, uuid: UUID)
+  def split(residualQuantity: Long): (LimitBidOrder, LimitBidOrder) = {
+    val filledQuantity = quantity - residualQuantity
+    (this.copy(quantity = filledQuantity), this.copy(quantity = residualQuantity))
   }
 
 }

--- a/src/main/scala-2.11/markets/orders/market/MarketAskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/market/MarketAskOrder.scala
@@ -31,8 +31,9 @@ case class MarketAskOrder(issuer: ActorRef,
 
   val price: Long = 0
 
-  def split(newQuantity: Long): MarketAskOrder = {
-    MarketAskOrder(issuer, newQuantity, timestamp, tradable, uuid)
+  def split(residualQuantity: Long): (MarketAskOrder, MarketAskOrder) = {
+    val filledQuantity = quantity - residualQuantity
+    (this.copy(quantity = filledQuantity), this.copy(quantity = residualQuantity))
   }
 
 }

--- a/src/main/scala-2.11/markets/orders/market/MarketBidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/market/MarketBidOrder.scala
@@ -31,8 +31,9 @@ case class MarketBidOrder(issuer: ActorRef,
 
   val price: Long = Long.MaxValue
 
-  def split(newQuantity: Long): MarketBidOrder = {
-    MarketBidOrder(issuer, newQuantity, timestamp, tradable, uuid)
+  def split(remainingQuantity: Long): (MarketBidOrder, MarketBidOrder) = {
+    val filledQuantity = quantity - remainingQuantity
+    (this.copy(quantity = filledQuantity), this.copy(quantity = remainingQuantity))
   }
 
 }

--- a/src/test/scala-2.11/markets/clearing/engines/CDAMatchingEngineSpec.scala
+++ b/src/test/scala-2.11/markets/clearing/engines/CDAMatchingEngineSpec.scala
@@ -231,7 +231,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual bid order landed in the book
       val residualBidQuantity = bidQuantity - askQuantity
-      val residualBidOrder = bidOrder.split(residualBidQuantity)
+      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
     }
@@ -268,7 +268,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual bid order landed in the book
       val residualBidQuantity = bidQuantity - askQuantity
-      val residualBidOrder = marketBidOrder.split(residualBidQuantity)
+      val (_, residualBidOrder) = marketBidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder, limitBidOrder))
 
     }
@@ -298,7 +298,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual bid order landed in the book
       val residualBidQuantity = bidQuantity - askQuantity
-      val residualBidOrder = bidOrder.split(residualBidQuantity)
+      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
     }
@@ -326,7 +326,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual ask order landed in the book
       val residualAskQuantity = askQuantity - bidQuantity
-      val residualAskOrder = askOrder.split(residualAskQuantity)
+      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
       // also should check that bid order book is now empty
@@ -355,7 +355,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual ask order landed in the book
       val residualAskQuantity = askQuantity - bidQuantity
-      val residualAskOrder = askOrder.split(residualAskQuantity)
+      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
       // also should check that bid order book is now empty
@@ -440,7 +440,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual ask order landed in the book
       val residualAskQuantity = askQuantity - bidQuantity
-      val residualAskOrder = askOrder.split(residualAskQuantity)
+      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
     }
@@ -472,7 +472,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
       val partialFill = PartialMatch(marketBidOrder, askOrder, bidPrice)
 
       val residualAskQuantity = askQuantity - marketBidQuantity
-      val residualAskOrder = askOrder.split(residualAskQuantity)
+      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       val totalFill = TotalMatch(limitBidOrder, residualAskOrder, bidPrice)
       val expectedFilledOrders = immutable.Queue(partialFill, totalFill)
       fills should equal(Some(expectedFilledOrders))
@@ -482,7 +482,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual bid order landed in the book
       val residualBidQuantity = limitBidQuantity - residualAskQuantity
-      val residualBidOrder = limitBidOrder.split(residualBidQuantity)
+      val (_, residualBidOrder) = limitBidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
     }
@@ -512,7 +512,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual ask order landed in the book
       val residualAskQuantity = askQuantity - bidQuantity
-      val residualAskOrder = askOrder.split(residualAskQuantity)
+      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
     }
@@ -540,7 +540,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual bid order landed in the book
       val residualBidQuantity = bidQuantity - askQuantity
-      val residualBidOrder = bidOrder.split(residualBidQuantity)
+      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
       // also should check that ask order book is now empty
@@ -569,7 +569,7 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       // also need to check that residual bid order landed in the book
       val residualBidQuantity = bidQuantity - askQuantity
-      val residualBidOrder = bidOrder.split(residualBidQuantity)
+      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
       // also should check that ask order book is now empty

--- a/src/test/scala-2.11/markets/clearing/engines/CDAMatchingEngineSpec.scala
+++ b/src/test/scala-2.11/markets/clearing/engines/CDAMatchingEngineSpec.scala
@@ -223,15 +223,15 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a TotalMatch")
 
-      val fill = TotalMatch(bidOrder, askOrder, bidPrice)
+      val residualBidQuantity = bidQuantity - askQuantity
+      val (filledBidOrder, residualBidOrder) = bidOrder.split(residualBidQuantity)
+      val fill = TotalMatch(filledBidOrder, askOrder, bidPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also should check that ask order book is now empty
       matchingEngine.askOrderBook.toSeq.isEmpty should be(true)
 
       // also need to check that residual bid order landed in the book
-      val residualBidQuantity = bidQuantity - askQuantity
-      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
     }
@@ -260,15 +260,15 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a TotalMatch at the best limit price.")
 
-      val fill = TotalMatch(marketBidOrder, askOrder, bidPrice)
+      val residualBidQuantity = bidQuantity - askQuantity
+      val (filledBidOrder, residualBidOrder) = marketBidOrder.split(residualBidQuantity)
+      val fill = TotalMatch(filledBidOrder, askOrder, bidPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also should check that ask order book is now empty
       matchingEngine.askOrderBook.toSeq.isEmpty should be(true)
 
       // also need to check that residual bid order landed in the book
-      val residualBidQuantity = bidQuantity - askQuantity
-      val (_, residualBidOrder) = marketBidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder, limitBidOrder))
 
     }
@@ -289,16 +289,15 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
       val fills = matchingEngine.findMatch(askOrder)
 
       Then("the matching engine should generate a TotalMatch")
-
-      val fill = TotalMatch(bidOrder, askOrder, bidPrice)
+      val residualBidQuantity = bidQuantity - askQuantity
+      val (filledBidOrder, residualBidOrder) = bidOrder.split(residualBidQuantity)
+      val fill = TotalMatch(filledBidOrder, askOrder, bidPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also should check that ask order book is now empty
       matchingEngine.askOrderBook.toSeq.isEmpty should be(true)
 
       // also need to check that residual bid order landed in the book
-      val residualBidQuantity = bidQuantity - askQuantity
-      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
     }
@@ -321,12 +320,12 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a PartialMatch")
 
-      val fill = PartialMatch(bidOrder, askOrder, bidPrice)
+      val residualAskQuantity = askQuantity - bidQuantity
+      val (filledAskOrder, residualAskOrder) = askOrder.split(residualAskQuantity)
+      val fill = PartialMatch(bidOrder, filledAskOrder, bidPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also need to check that residual ask order landed in the book
-      val residualAskQuantity = askQuantity - bidQuantity
-      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
       // also should check that bid order book is now empty
@@ -350,12 +349,12 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a PartialMatch")
 
-      val fill = PartialMatch(bidOrder, askOrder, bidPrice)
+      val residualAskQuantity = askQuantity - bidQuantity
+      val (filledAskOrder, residualAskOrder) = askOrder.split(residualAskQuantity)
+      val fill = PartialMatch(bidOrder, filledAskOrder, bidPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also need to check that residual ask order landed in the book
-      val residualAskQuantity = askQuantity - bidQuantity
-      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
       // also should check that bid order book is now empty
@@ -432,15 +431,15 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a TotalMatch")
 
-      val fill = TotalMatch(askOrder, bidOrder, askPrice)
+      val residualAskQuantity = askQuantity - bidQuantity
+      val (filledAskOrder, residualAskOrder) = askOrder.split(residualAskQuantity)
+      val fill = TotalMatch(filledAskOrder, bidOrder, askPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also should check that bid order book is now empty
       matchingEngine.bidOrderBook.toSeq.isEmpty should be(true)
 
       // also need to check that residual ask order landed in the book
-      val residualAskQuantity = askQuantity - bidQuantity
-      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
     }
@@ -469,11 +468,13 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a PartialMatch at the best limit price.")
 
-      val partialFill = PartialMatch(marketBidOrder, askOrder, bidPrice)
-
       val residualAskQuantity = askQuantity - marketBidQuantity
-      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
-      val totalFill = TotalMatch(limitBidOrder, residualAskOrder, bidPrice)
+      val (filledAskOrder, residualAskOrder) = askOrder.split(residualAskQuantity)
+      val partialFill = PartialMatch(marketBidOrder, filledAskOrder, bidPrice)
+
+      val residualBidQuantity = limitBidQuantity - residualAskQuantity
+      val (filledBidOrder, residualBidOrder) = limitBidOrder.split(residualBidQuantity)
+      val totalFill = TotalMatch(filledBidOrder, residualAskOrder, bidPrice)
       val expectedFilledOrders = immutable.Queue(partialFill, totalFill)
       fills should equal(Some(expectedFilledOrders))
 
@@ -481,8 +482,6 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
       matchingEngine.askOrderBook.toSeq.isEmpty should be(true)
 
       // also need to check that residual bid order landed in the book
-      val residualBidQuantity = limitBidQuantity - residualAskQuantity
-      val (_, residualBidOrder) = limitBidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
     }
@@ -504,15 +503,15 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a TotalMatch")
 
-      val fill = TotalMatch(askOrder, bidOrder, askPrice)
+      val residualAskQuantity = askQuantity - bidQuantity
+      val (filledAskOrder, residualAskOrder) = askOrder.split(residualAskQuantity)
+      val fill = TotalMatch(filledAskOrder, bidOrder, askPrice)
       fills should equal(Some(immutable.Queue(fill)))
 
       // also should check that bid order book is now empty
       matchingEngine.bidOrderBook.toSeq.isEmpty should be(true)
 
       // also need to check that residual ask order landed in the book
-      val residualAskQuantity = askQuantity - bidQuantity
-      val (_, residualAskOrder) = askOrder.split(residualAskQuantity)
       matchingEngine.askOrderBook.toSeq should equal(immutable.Seq(residualAskOrder))
 
     }
@@ -535,12 +534,12 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a PartialMatch")
 
-      val fill = PartialMatch(askOrder, bidOrder, askPrice)
+      val residualBidQuantity = bidQuantity - askQuantity
+      val (filledBidOrder, residualBidOrder) = bidOrder.split(residualBidQuantity)
+      val fill = PartialMatch(askOrder, filledBidOrder, askPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also need to check that residual bid order landed in the book
-      val residualBidQuantity = bidQuantity - askQuantity
-      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
       // also should check that ask order book is now empty
@@ -564,12 +563,12 @@ class CDAMatchingEngineSpec extends TestKit(ActorSystem("CDAMatchingEngineSpec")
 
       Then("the matching engine should generate a PartialMatch")
 
-      val fill = PartialMatch(askOrder, bidOrder, askPrice)
+      val residualBidQuantity = bidQuantity - askQuantity
+      val (filledBidOrder, residualBidOrder) = bidOrder.split(residualBidQuantity)
+      val fill = PartialMatch(askOrder, filledBidOrder, askPrice)
       fills should equal(Some(immutable.Queue[Match](fill)))
 
       // also need to check that residual bid order landed in the book
-      val residualBidQuantity = bidQuantity - askQuantity
-      val (_, residualBidOrder) = bidOrder.split(residualBidQuantity)
       matchingEngine.bidOrderBook.toSeq should equal(immutable.Seq(residualBidOrder))
 
       // also should check that ask order book is now empty


### PR DESCRIPTION
PR refactors the split method to return a tuple of the form `(filledOrder, residualOrder)`.
