### PR TITLE
No longer need an Accepted message.

### DIFF
--- a/src/main/scala-2.11/markets/MarketActor.scala
+++ b/src/main/scala-2.11/markets/MarketActor.scala
@@ -41,7 +41,6 @@ case class MarketActor(matchingEngine: MatchingEngine,
   def marketActorBehavior: Receive = {
     case order: Order =>
       if(order.tradable == tradable) {
-        sender() tell(Accepted(order, timestamp(), uuid()), self)
         matchingEngine.findMatch(order) match {
           case Some(matchings) =>
             matchings.foreach { matching =>

--- a/src/main/scala-2.11/markets/package.scala
+++ b/src/main/scala-2.11/markets/package.scala
@@ -64,14 +64,6 @@ package object markets {
     */
   case class Remove(timestamp: Long, tradable: Tradable, uuid: UUID) extends Message
 
-  /** Message sent from a `MarketActor` to some `MarketParticipant` actor indicating that its
-    * order has been accepted.
-    * @param order
-    * @param timestamp
-    * @param uuid
-    */
-  case class Accepted(order: Order, timestamp: Long, uuid: UUID) extends Message
-
   /** Message sent from a `MarketParticipant` actor to some `MarketActor` indicating that it
     * wishes to cancel a previously submitted order.
     * @param order

--- a/src/main/scala-2.11/markets/participants/LiquidityDemander.scala
+++ b/src/main/scala-2.11/markets/participants/LiquidityDemander.scala
@@ -17,6 +17,8 @@ package markets.participants
 
 import akka.actor.Scheduler
 
+import markets.orders.Order
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
@@ -24,7 +26,7 @@ import scala.concurrent.duration.FiniteDuration
 /** A Trait providing behavior necessary to submit `MarketOrderLike` orders. */
 trait LiquidityDemander extends MarketParticipant {
 
-  def submitMarketOrder(): Unit
+  def generateMarketOrder(): Order
 
   /** Schedule a market order.
     *
@@ -53,7 +55,9 @@ trait LiquidityDemander extends MarketParticipant {
   }
 
   override def receive: Receive = {
-    case SubmitMarketOrder => submitMarketOrder()
+    case SubmitMarketOrder =>
+      val marketOrder = generateMarketOrder()
+      submit(marketOrder)
     case message => super.receive(message)
   }
 

--- a/src/main/scala-2.11/markets/participants/LiquiditySupplier.scala
+++ b/src/main/scala-2.11/markets/participants/LiquiditySupplier.scala
@@ -17,14 +17,16 @@ package markets.participants
 
 import akka.actor.Scheduler
 
+import markets.orders.Order
+
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.ExecutionContext
 
 
-/** Mixin Trait providing behavior necessary to submit `LimitOrderLike` orders. */
+/** Mixin Trait providing behavior necessary to generate `LimitOrderLike` orders. */
 trait LiquiditySupplier extends MarketParticipant {
 
-  def submitLimitOrder(): Unit
+  def generateLimitOrder(): Order
 
   /** Schedule a limit order.
     *
@@ -53,7 +55,9 @@ trait LiquiditySupplier extends MarketParticipant {
   }
 
   override def receive: Receive = {
-    case SubmitLimitOrder => submitLimitOrder()
+    case SubmitLimitOrder =>
+      val limitOrder = generateLimitOrder()
+      submit(limitOrder)
     case message => super.receive(message)
   }
 

--- a/src/test/scala-2.11/markets/ExchangeActorSpec.scala
+++ b/src/test/scala-2.11/markets/ExchangeActorSpec.scala
@@ -61,7 +61,7 @@ class ExchangeActorSpec extends TestKit(ActorSystem("ExchangeActorSpec"))
       testExchange tell(validOrder, marketParticipant.ref)
 
       Then("...it should create a child MarketActor and forward the order.")
-      marketParticipant.expectMsgAllClassOf[Accepted]()
+      marketParticipant.expectNoMsg()
 
     }
   }

--- a/src/test/scala-2.11/markets/MarketActorSpec.scala
+++ b/src/test/scala-2.11/markets/MarketActorSpec.scala
@@ -70,7 +70,7 @@ class MarketActorSpec extends TestKit(ActorSystem("MarketActorSpec"))
       }
 
       Then("...it should notify the sender that the order has been accepted.")
-      marketParticipant.expectMsgAllClassOf[Accepted]()
+      marketParticipant.expectNoMsg()
 
     }
 

--- a/src/test/scala-2.11/markets/participants/OrderCancelerSpec.scala
+++ b/src/test/scala-2.11/markets/participants/OrderCancelerSpec.scala
@@ -21,7 +21,7 @@ import akka.testkit.{TestProbe, TestActorRef, TestKit}
 
 import java.util.UUID
 
-import markets.{Cancel, Accepted}
+import markets.Cancel
 import markets.orders.limit.LimitAskOrder
 import markets.tickers.Tick
 import markets.tradables.TestTradable
@@ -72,8 +72,7 @@ class OrderCancelerSpec extends TestKit(ActorSystem("OrderCancelerSpec"))
 
       When("An OrderCanceler has some outstanding orders...")
       val order = LimitAskOrder(orderCancelerRef, 10, 100, timestamp(), tradable, uuid())
-      val accepted = Accepted(order, timestamp(), uuid())
-      orderCancelerRef ! accepted
+      orderCancelerActor.outstandingOrders += order
 
       orderCancelerActor.scheduleOrderCancellation(system.scheduler, initialDelay)
 

--- a/src/test/scala-2.11/markets/participants/TestLiquidityDemander.scala
+++ b/src/test/scala-2.11/markets/participants/TestLiquidityDemander.scala
@@ -19,7 +19,7 @@ import akka.actor.{Props, ActorRef}
 import akka.agent.Agent
 
 import markets.orders.Order
-import markets.orders.market.{MarketBidOrder, MarketAskOrder, MarketOrderLike}
+import markets.orders.market.{MarketAskOrder, MarketBidOrder}
 import markets.tickers.Tick
 import markets.tradables.Tradable
 
@@ -38,17 +38,13 @@ class TestLiquidityDemander(market: ActorRef,
 
   val tickers = mutable.Map(tradable -> ticker)
 
-  def generateMarketOrder(): MarketOrderLike = {
+  def generateMarketOrder(): Order = {
     if (prng.nextDouble() < 0.5) {
       MarketAskOrder(self, 1, timestamp(), tradable, uuid())
     } else {
       MarketBidOrder(self, 1, timestamp(), tradable, uuid())
     }
 
-  }
-
-  def submitMarketOrder(): Unit = {
-    market tell(generateMarketOrder(), self)
   }
 
 }

--- a/src/test/scala-2.11/markets/participants/TestLiquiditySupplier.scala
+++ b/src/test/scala-2.11/markets/participants/TestLiquiditySupplier.scala
@@ -19,7 +19,7 @@ import akka.actor.{Props, ActorRef}
 import akka.agent.Agent
 
 import markets.orders.Order
-import markets.orders.limit.{LimitBidOrder, LimitAskOrder, LimitOrderLike}
+import markets.orders.limit.{LimitAskOrder, LimitBidOrder}
 import markets.tickers.Tick
 import markets.tradables.Tradable
 
@@ -38,16 +38,12 @@ class TestLiquiditySupplier(market: ActorRef,
 
   val tickers = mutable.Map(tradable -> ticker)
 
-  def generateLimitOrder(): LimitOrderLike = {
+  def generateLimitOrder(): Order = {
     if (prng.nextDouble() < 0.5) {
       LimitAskOrder(self, 1, 1, timestamp(), tradable, uuid())
     } else {
       LimitBidOrder(self, 1, 1, timestamp(), tradable, uuid())
     }
-  }
-
-  def submitLimitOrder(): Unit = {
-    market tell(generateLimitOrder(), self)
   }
 
 }


### PR DESCRIPTION
This PR removes the `Accepted` message and refactors the `MarketParticipant` actor to add orders to `outstandingOrders` collection just prior to submission...
