### PR TITLE
Refactor order cancellation strategy.

### DIFF
--- a/src/main/scala-2.11/markets/participants/strategies/OrderCancellationStrategy.scala
+++ b/src/main/scala-2.11/markets/participants/strategies/OrderCancellationStrategy.scala
@@ -7,6 +7,6 @@ import scala.collection.mutable
 
 trait OrderCancellationStrategy {
 
-  def cancelOneOf(outstandingOrders: mutable.Iterable[Order]): Option[Order]
+  def cancelOneOf[T <: mutable.Iterable[Order]](outstandingOrders: T): Option[Order]
 
 }

--- a/src/test/scala-2.11/markets/participants/strategies/TestOrderCancellationStrategy.scala
+++ b/src/test/scala-2.11/markets/participants/strategies/TestOrderCancellationStrategy.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 
 class TestOrderCancellationStrategy extends OrderCancellationStrategy {
 
-  def cancelOneOf(outstandingOrders: mutable.Iterable[Order]): Option[Order] = {
+  def cancelOneOf[T <: mutable.Iterable[Order]](outstandingOrders: T): Option[Order] = {
     outstandingOrders.headOption
   }
 


### PR DESCRIPTION
Order cancellation strategy should work for generic `mutable.Iterable`.
