### PR TITLE
Hotfix matchings

### DIFF
--- a/src/main/scala-2.11/markets/engines/CDAMatchingEngine.scala
+++ b/src/main/scala-2.11/markets/engines/CDAMatchingEngine.scala
@@ -87,7 +87,8 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
             mostRecentPrice = possiblePrices.min  // SIDE EFFECT!
             mostRecentPrice
           case None =>
-            mostRecentPrice = incoming.price  // SIDE EFFECT!
+            val possiblePrices = immutable.Seq(incoming.price, mostRecentPrice)
+            mostRecentPrice = possiblePrices.min  // SIDE EFFECT!
             mostRecentPrice
         }
       case (_, _: MarketBidOrder) =>
@@ -97,7 +98,8 @@ class CDAMatchingEngine(askOrdering: PriceOrdering[AskOrder],
             mostRecentPrice = possiblePrices.max  // SIDE EFFECT!
             mostRecentPrice
           case None =>
-            mostRecentPrice = incoming.price  // SIDE EFFECT!
+            val possiblePrices = immutable.Seq(incoming.price, mostRecentPrice)
+            mostRecentPrice = possiblePrices.max  // SIDE EFFECT!
             mostRecentPrice
         }
     }

--- a/src/main/scala-2.11/markets/engines/Matching.scala
+++ b/src/main/scala-2.11/markets/engines/Matching.scala
@@ -35,6 +35,7 @@ case class Matching(askOrder: AskOrder,
                     residualAskOrder: Option[AskOrder],
                     residualBidOrder: Option[BidOrder]) {
 
-  require(0 < price && price < Long.MaxValue, "Price must be feasible")
+  require(0 < price, s"Price $price is not strictly positive!")
+  require(price < Long.MaxValue, s"Price $price must be strictly less than ${Long.MaxValue}!")
 
 }


### PR DESCRIPTION
Fixed a bug in the `formPrice` method that was causing errors to be thrown when creating a `Matching`...
