### PR TITLE
Now you need to add (remove) markets and tickers using message passing.

### DIFF
--- a/src/main/scala-2.11/markets/actors/package.scala
+++ b/src/main/scala-2.11/markets/actors/package.scala
@@ -9,35 +9,11 @@ import markets.orders.Order
 import markets.tickers.Tick
 import markets.tradables.Tradable
 
-/**
-  * Created by drpugh on 4/27/16.
-  */
+
 package object actors {
 
-  /** Message sent to some `MarketParticipant` actor indicating that the actor should add a
-    * particular market to the collection of markets on which it trades.
-    * @param market
-    * @param ticker
-    * @param timestamp
-    * @param tradable
-    * @param uuid
-    */
-  case class Add(market: ActorRef,
-                 ticker: Agent[Tick],
-                 timestamp: Long,
-                 tradable: Tradable,
-                 uuid: UUID) extends Message
-
-  /** Message sent to some `MarketParticipant` actor indicating that the actor should remove a
-    * particular market from the collection of markets on which it trades.
-    * @param timestamp
-    * @param tradable
-    * @param uuid
-    */
-  case class Remove(timestamp: Long, tradable: Tradable, uuid: UUID) extends Message
-
-  /** Message sent from ??? to some `MarketParticipant` actor indicating that a previously
-    * submitted order has been filled.
+  /** Message sent from a `MarketActor` to some `MarketParticipant` actor indicating that a
+    * previously submitted order has been filled.
     * @param order
     * @param residual
     * @param timestamp

--- a/src/main/scala-2.11/markets/actors/participants/MarketParticipant.scala
+++ b/src/main/scala-2.11/markets/actors/participants/MarketParticipant.scala
@@ -18,23 +18,25 @@ package markets.actors.participants
 import akka.actor.ActorRef
 import akka.agent.Agent
 
-import markets.actors.{Add, Remove, StackableActor}
+import markets.actors.StackableActor
 import markets.tickers.Tick
 import markets.tradables.Tradable
+
+import scala.collection.immutable
 
 
 /** Base Trait for all market participants. */
 trait MarketParticipant extends StackableActor {
 
-  var markets: Map[Tradable, ActorRef]
+  var markets: immutable.Map[Tradable, ActorRef]
 
-  var tickers: Map[Tradable, Agent[Tick]]
+  var tickers: immutable.Map[Tradable, Agent[Tick]]
 
   override def receive: Receive = {
-    case Add(market, ticker, _, tradable, _) =>
+    case Add(tradable, market, ticker) =>
       markets += (tradable -> market)
       tickers += (tradable -> ticker)
-    case Remove(_, tradable, _) =>
+    case Remove(tradable) =>
       markets -= tradable
       tickers -= tradable
     case message =>

--- a/src/main/scala-2.11/markets/actors/participants/OrderCanceler.scala
+++ b/src/main/scala-2.11/markets/actors/participants/OrderCanceler.scala
@@ -31,7 +31,7 @@ trait OrderCanceler {
   def outstandingOrders: mutable.Set[Order]
 
   def orderCancelerBehavior: Receive = {
-    case SubmitOrderCancellation =>
+    case IssueOrderCancellation =>
       val canceledOrder = orderCancellationStrategy.cancelOneOf(outstandingOrders)
       canceledOrder match {
         case Some(order) =>

--- a/src/main/scala-2.11/markets/actors/participants/OrderIssuer.scala
+++ b/src/main/scala-2.11/markets/actors/participants/OrderIssuer.scala
@@ -31,7 +31,7 @@ trait OrderIssuer {
   def bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder]
 
   def orderIssuerBehavior: Receive = {
-    case SubmitAskOrder =>
+    case IssueAskOrder =>
       askOrderIssuingStrategy.investmentStrategy(tickers) match {
         case Some(tradable) =>
           val ticker = tickers(tradable)
@@ -43,7 +43,7 @@ trait OrderIssuer {
           }
         case None =>  // no feasible investment strategy!
       }
-    case SubmitBidOrder =>
+    case IssueBidOrder =>
       bidOrderIssuingStrategy.investmentStrategy(tickers) match {
         case Some(tradable) =>
           val ticker = tickers(tradable)

--- a/src/main/scala-2.11/markets/actors/participants/package.scala
+++ b/src/main/scala-2.11/markets/actors/participants/package.scala
@@ -15,15 +15,37 @@ limitations under the License.
 */
 package markets.actors
 
+import akka.actor.ActorRef
+import akka.agent.Agent
+
+import markets.tickers.Tick
+import markets.tradables.Tradable
+
 
 package object participants {
 
-  class SubmitOrder
+  /** Message sent to a `MarketParticipant` indicating that it should add a particular market to
+    * its collections of markets and tickers.
+    *
+    * @param tradable
+    * @param market
+    * @param ticker
+    */
+  case class Add(tradable: Tradable, market: ActorRef, ticker: Agent[Tick])
 
-  object SubmitAskOrder extends SubmitOrder
+  /** Message sent to a `MarketParticipant` indicating that it should remove a particular market
+    * from tits collection of markets and tickers.
+    *
+    * @param tradable
+    */
+  case class Remove(tradable: Tradable)
 
-  object SubmitBidOrder extends SubmitOrder
+  class IssueOrder
 
-  object SubmitOrderCancellation
+  object IssueAskOrder extends IssueOrder
+
+  object IssueBidOrder extends IssueOrder
+
+  object IssueOrderCancellation
 
 }

--- a/src/performance/scala-2.11/markets/MutableCDAMarketActorBenchmarkSimulation.scala
+++ b/src/performance/scala-2.11/markets/MutableCDAMarketActorBenchmarkSimulation.scala
@@ -20,8 +20,6 @@ import akka.agent.Agent
 import akka.routing.{Broadcast, FromConfig}
 import akka.testkit.TestKit
 
-import java.util.UUID
-
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import markets.actors.MutableTreeSetCDAMarketActor
 import markets.orders.orderings.ask.AskPriceTimeOrdering

--- a/src/test/scala-2.11/markets/actors/participants/MarketParticipantSpec.scala
+++ b/src/test/scala-2.11/markets/actors/participants/MarketParticipantSpec.scala
@@ -20,7 +20,6 @@ import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 
 import markets.MarketsTestKit
-import markets.actors.{Add, Remove}
 import markets.tickers.Tick
 import markets.tradables.Tradable
 import org.scalatest.{FeatureSpecLike, GivenWhenThen, Matchers}
@@ -37,27 +36,20 @@ class MarketParticipantSpec extends TestKit(ActorSystem("MarketParticipantSpec")
     system.terminate()
   }
 
-  val tradable = Tradable("GOOG")
-
-  val market = TestProbe()
-  val markets = Map[Tradable, ActorRef](tradable -> market.ref)
-
-  val initialTick = Tick(1, 1, 1, 1, timestamp())
-  val tickers = Map[Tradable, Agent[Tick]](tradable -> Agent(initialTick)(system.dispatcher))
-
   feature("A MarketParticipant should be able to add and remove markets.") {
 
-    val markets = Map.empty[Tradable, ActorRef]
-    val tickers = Map.empty[Tradable, Agent[Tick]]
-    val props = TestMarketParticipant.props(markets, tickers)
+    val tradable = Tradable("GOOG")
+
+    val props = TestMarketParticipant.props()
     val marketParticipantRef = TestActorRef[TestMarketParticipant](props)
     val marketParticipantActor = marketParticipantRef.underlyingActor
 
     scenario("A MarketParticipant receives an Add message...") {
 
       val market = testActor
+      val initialTick = Tick(1, 1, 1, 1, timestamp())
       val ticker = Agent(initialTick)(system.dispatcher)
-      val add = Add(market, ticker, timestamp(), tradable, uuid())
+      val add = Add(tradable, market, ticker)
 
       When("A MarketParticipant receives an Add message...")
       marketParticipantRef ! add
@@ -71,7 +63,7 @@ class MarketParticipantSpec extends TestKit(ActorSystem("MarketParticipantSpec")
     scenario("A MarketParticipant receives a Remove message...") {
 
       When("A MarketParticipant receives a Remove message...")
-      val remove = Remove(timestamp(), tradable, uuid())
+      val remove = Remove(tradable)
       marketParticipantRef ! remove
 
       Then("...it should remove the market from its collection of markets.")
@@ -81,4 +73,5 @@ class MarketParticipantSpec extends TestKit(ActorSystem("MarketParticipantSpec")
     }
 
   }
+
 }

--- a/src/test/scala-2.11/markets/actors/participants/TestMarketParticipant.scala
+++ b/src/test/scala-2.11/markets/actors/participants/TestMarketParticipant.scala
@@ -18,32 +18,25 @@ package markets.actors.participants
 import akka.actor.{ActorRef, Props}
 import akka.agent.Agent
 
-import markets.actors.participants.strategies.trading.TradingStrategy
 import markets.tickers.Tick
 import markets.tradables.Tradable
 
-import scala.collection.mutable
 
+/** Stub implementation of the
+  * [[markets.actors.participants.MarketParticipant `MarketParticipant']] trait for testing. */
+class TestMarketParticipant extends MarketParticipant {
 
-/** Class representing a stub implementation of the MarketParticipant trait for testing.
-  *
-  * @param markets
-  * @param tickers
-  */
-class TestMarketParticipant(var markets: Map[Tradable, ActorRef],
-                            var tickers: Map[Tradable, Agent[Tick]])
-  extends MarketParticipant
+  var markets = Map.empty[Tradable, ActorRef]
+
+  var tickers = Map.empty[Tradable, Agent[Tick]]
+
+}
 
 
 object TestMarketParticipant {
 
-  def apply(markets: Map[Tradable, ActorRef],
-            tickers: Map[Tradable, Agent[Tick]]): TestMarketParticipant = {
-    new TestMarketParticipant(markets, tickers)
+  def props(): Props = {
+    Props(new TestMarketParticipant)
   }
 
-  def props(markets: Map[Tradable, ActorRef],
-            tickers: Map[Tradable, Agent[Tick]]): Props = {
-    Props(new TestMarketParticipant(markets, tickers))
-  }
 }

--- a/src/test/scala-2.11/markets/actors/participants/TestOrderCanceler.scala
+++ b/src/test/scala-2.11/markets/actors/participants/TestOrderCanceler.scala
@@ -15,23 +15,18 @@ limitations under the License.
 */
 package markets.actors.participants
 
-import akka.actor.{ActorRef, Props}
-import akka.agent.Agent
+import akka.actor.Props
 
 import markets.orders.{AskOrder, BidOrder, Order}
 import markets.actors.participants.strategies.{OrderCancellationStrategy, OrderIssuingStrategy}
-import markets.tickers.Tick
-import markets.tradables.Tradable
 
 import scala.collection.mutable
 
 
-class TestOrderCanceler(markets: Map[Tradable, ActorRef],
-                        tickers: Map[Tradable, Agent[Tick]],
-                        askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
+class TestOrderCanceler(askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
                         bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder],
                         val orderCancellationStrategy: OrderCancellationStrategy)
-  extends TestOrderIssuer(markets, tickers, askOrderIssuingStrategy, bidOrderIssuingStrategy)
+  extends TestOrderIssuer(askOrderIssuingStrategy, bidOrderIssuingStrategy)
   with OrderCanceler {
 
   val outstandingOrders = mutable.Set.empty[Order]
@@ -43,22 +38,10 @@ class TestOrderCanceler(markets: Map[Tradable, ActorRef],
 
 object TestOrderCanceler {
 
-  def apply(markets: Map[Tradable, ActorRef],
-            tickers: Map[Tradable, Agent[Tick]],
-            askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
-            bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder],
-            cancellationStrategy: OrderCancellationStrategy): TestOrderCanceler = {
-    new TestOrderCanceler(markets, tickers, askOrderIssuingStrategy, bidOrderIssuingStrategy,
-      cancellationStrategy)
-  }
-
-  def props(markets: Map[Tradable, ActorRef],
-            tickers: Map[Tradable, Agent[Tick]],
-            askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
+  def props(askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
             bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder],
             cancellationStrategy: OrderCancellationStrategy): Props = {
-    Props(new TestOrderCanceler(markets, tickers, askOrderIssuingStrategy, bidOrderIssuingStrategy,
-      cancellationStrategy))
+    Props(new TestOrderCanceler(askOrderIssuingStrategy, bidOrderIssuingStrategy, cancellationStrategy))
   }
 
 }

--- a/src/test/scala-2.11/markets/actors/participants/TestOrderIssuer.scala
+++ b/src/test/scala-2.11/markets/actors/participants/TestOrderIssuer.scala
@@ -15,27 +15,20 @@ limitations under the License.
 */
 package markets.actors.participants
 
-import akka.actor.{ActorRef, Props}
-import akka.agent.Agent
+import akka.actor.Props
 
 import markets.actors.participants.strategies.OrderIssuingStrategy
 import markets.orders.{AskOrder, BidOrder}
-import markets.tickers.Tick
-import markets.tradables.Tradable
 
 
 /** A stub implementation of the `OrderIssuer` trait for testing purposes only.
   *
-  * @param markets
-  * @param tickers
   * @param askOrderIssuingStrategy
   * @param bidOrderIssuingStrategy
   */
-class TestOrderIssuer(markets: Map[Tradable, ActorRef],
-                      tickers: Map[Tradable, Agent[Tick]],
-                      val askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
+class TestOrderIssuer(val askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
                       val bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder])
-  extends TestMarketParticipant(markets, tickers)
+  extends TestMarketParticipant
   with OrderIssuer {
 
   wrappedBecome(orderIssuerBehavior)
@@ -45,18 +38,9 @@ class TestOrderIssuer(markets: Map[Tradable, ActorRef],
 
 object TestOrderIssuer {
 
-  def apply(markets: Map[Tradable, ActorRef],
-            tickers: Map[Tradable, Agent[Tick]],
-            askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
-            bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder]): TestOrderIssuer = {
-    new TestOrderIssuer(markets, tickers, askOrderIssuingStrategy, bidOrderIssuingStrategy)
-  }
-
-  def props(markets: Map[Tradable, ActorRef],
-            tickers: Map[Tradable, Agent[Tick]],
-            askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
+  def props(askOrderIssuingStrategy: OrderIssuingStrategy[AskOrder],
             bidOrderIssuingStrategy: OrderIssuingStrategy[BidOrder]): Props = {
-    Props(TestOrderIssuer(markets, tickers, askOrderIssuingStrategy, bidOrderIssuingStrategy))
+    Props(new TestOrderIssuer(askOrderIssuingStrategy, bidOrderIssuingStrategy))
   }
 
 }


### PR DESCRIPTION
This PR makes market simulations more immutable by forcing the user to explicitly pass market refs and ticker agent refs as messages.
