### PR TITLE
Removed split method from orders for now.

### DIFF
--- a/src/main/scala-2.11/markets/orders/AskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/AskOrder.scala
@@ -30,15 +30,6 @@ trait AskOrder extends Order {
     case order: BidOrder if this.tradable == order.tradable => this.price <= order.price
   }
 
-  /** Splits an existing `AskOrder` into two separate orders.
-    *
-    * @param residualQuantity the quantity of the residual, unfilled portion of the `AskOrder`.
-    * @return a tuple of ask orders.
-    * @note The first order in the tuple represents the filled portion of the `AskOrder`; the
-    *       second order in the tuple represents the residual, unfilled portion of the `AskOrder`.
-    */
-  def split(residualQuantity: Long): (AskOrder, AskOrder)
-
 }
 
 

--- a/src/main/scala-2.11/markets/orders/BidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/BidOrder.scala
@@ -30,15 +30,6 @@ trait BidOrder extends Order {
     case order: AskOrder if this.tradable == order.tradable => this.price >= order.price
   }
 
-  /** Splits an existing `BidOrder` into two separate orders.
-    *
-    * @param residualQuantity the quantity of the residual, unfilled portion of the `BidOrder`.
-    * @return a tuple of bid orders.
-    * @note The first order in the tuple represents the filled portion of the `BidOrder`; the
-    *       second order in the tuple represents the residual, unfilled portion of the `BidOrder`.
-    */
-  def split(residualQuantity: Long): (BidOrder, BidOrder)
-
 }
 
 

--- a/src/main/scala-2.11/markets/orders/limit/LimitAskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/limit/LimitAskOrder.scala
@@ -35,18 +35,4 @@ case class LimitAskOrder(issuer: UUID,
                          quantity: Long,
                          timestamp: Long,
                          tradable: Security,
-                         uuid: UUID) extends LimitOrder with AskOrder {
-
-  /** Splits an existing `LimitAskOrder` into two separate orders.
-    *
-    * @param residualQuantity the quantity of the residual, unfilled portion of the `LimitAskOrder`.
-    * @return a tuple of `LimitAskOrders`.
-    * @note The first order in the tuple represents the filled portion of the `LimitAskOrder`; the
-    *       second order in the tuple represents the residual, unfilled portion of the
-    *       `LimitAskOrder`.
-    */
-  def split(residualQuantity: Long): (LimitAskOrder, LimitAskOrder) = {
-    val filledQuantity = quantity - residualQuantity
-    (this.copy(quantity = filledQuantity), this.copy(quantity = residualQuantity))
-  }
-}
+                         uuid: UUID) extends LimitOrder with AskOrder

--- a/src/main/scala-2.11/markets/orders/limit/LimitBidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/limit/LimitBidOrder.scala
@@ -27,11 +27,4 @@ case class LimitBidOrder(issuer: UUID,
                          quantity: Long,
                          timestamp: Long,
                          tradable: Security,
-                         uuid: UUID) extends LimitOrder with BidOrder {
-
-  def split(residualQuantity: Long): (LimitBidOrder, LimitBidOrder) = {
-    val filledQuantity = quantity - residualQuantity
-    (this.copy(quantity = filledQuantity), this.copy(quantity = residualQuantity))
-  }
-
-}
+                         uuid: UUID) extends LimitOrder with BidOrder

--- a/src/main/scala-2.11/markets/orders/market/MarketAskOrder.scala
+++ b/src/main/scala-2.11/markets/orders/market/MarketAskOrder.scala
@@ -29,9 +29,4 @@ case class MarketAskOrder(issuer: UUID,
 
   val price: Long = 0
 
-  def split(residualQuantity: Long): (MarketAskOrder, MarketAskOrder) = {
-    val filledQuantity = quantity - residualQuantity
-    (this.copy(quantity = filledQuantity), this.copy(quantity = residualQuantity))
-  }
-
 }

--- a/src/main/scala-2.11/markets/orders/market/MarketBidOrder.scala
+++ b/src/main/scala-2.11/markets/orders/market/MarketBidOrder.scala
@@ -29,9 +29,4 @@ case class MarketBidOrder(issuer: UUID,
 
   val price: Long = Long.MaxValue
 
-  def split(remainingQuantity: Long): (MarketBidOrder, MarketBidOrder) = {
-    val filledQuantity = quantity - remainingQuantity
-    (this.copy(quantity = filledQuantity), this.copy(quantity = remainingQuantity))
-  }
-
 }

--- a/src/test/scala-2.11/markets/FillSpec.scala
+++ b/src/test/scala-2.11/markets/FillSpec.scala
@@ -41,11 +41,8 @@ class FillSpec extends FeatureSpec
 
     val price = (askPrice / 2) + (bidPrice / 2)  // watch out for overflow!!
     val filledQuantity = Math.min(askQuantity, bidQuantity)
-    val residualQuantity = Math.max(askQuantity, bidQuantity) - filledQuantity
-    val residualAsk = if (ask.quantity > bid.quantity) Some(ask.split(residualQuantity)._2) else None
-    val residualBid = if (bid.quantity > ask.quantity) Some(bid.split(residualQuantity)._2) else None
 
-    val matching = Matching(ask, bid, price, filledQuantity, residualAsk, residualBid)
+    val matching = Matching(ask, bid, price, filledQuantity, None, None)
 
     Then("that Matching instance should be used to create a Fill instance.")
 

--- a/src/test/scala-2.11/markets/orders/limit/LimitAskOrderSpec.scala
+++ b/src/test/scala-2.11/markets/orders/limit/LimitAskOrderSpec.scala
@@ -16,7 +16,6 @@ limitations under the License.
 package markets.orders.limit
 
 import markets.MarketsTestKit
-import markets.tradables.Security
 import org.scalatest.{FeatureSpec, GivenWhenThen, Matchers}
 
 import scala.util.Random
@@ -55,18 +54,6 @@ class LimitAskOrderSpec extends FeatureSpec
       )
 
     }
-  }
-
-  feature("A LimitAskOrder should be able to split itself into two separate orders.") {
-    val limitOrder = randomAskOrder(marketOrderProbability = 0.0, tradable = validTradable)
-
-    val filledQuantity = randomQuantity(upper=limitOrder.quantity)
-    val residualQuantity = limitOrder.quantity - filledQuantity
-    val (filledOrder, residualOrder) = limitOrder.split(residualQuantity)
-
-    filledOrder.quantity should be(filledQuantity)
-    residualOrder.quantity should be(residualQuantity)
-
   }
 
 }

--- a/src/test/scala-2.11/markets/orders/limit/LimitBidOrderSpec.scala
+++ b/src/test/scala-2.11/markets/orders/limit/LimitBidOrderSpec.scala
@@ -16,7 +16,6 @@ limitations under the License.
 package markets.orders.limit
 
 import markets.MarketsTestKit
-import markets.tradables.Security
 import org.scalatest.{FeatureSpec, GivenWhenThen, Matchers}
 
 import scala.util.Random
@@ -55,18 +54,6 @@ class LimitBidOrderSpec extends FeatureSpec
       )
 
     }
-  }
-
-  feature("A LimitBidOrder should be able to split itself into two separate orders.") {
-    val limitOrder = randomBidOrder(marketOrderProbability = 0.0, tradable = validTradable)
-
-    val filledQuantity = randomQuantity(upper=limitOrder.quantity)
-    val residualQuantity = limitOrder.quantity - filledQuantity
-    val (filledOrder, residualOrder) = limitOrder.split(residualQuantity)
-
-    filledOrder.quantity should be(filledQuantity)
-    residualOrder.quantity should be(residualQuantity)
-
   }
 
 }

--- a/src/test/scala-2.11/markets/orders/market/MarketAskOrderSpec.scala
+++ b/src/test/scala-2.11/markets/orders/market/MarketAskOrderSpec.scala
@@ -16,7 +16,6 @@ limitations under the License.
 package markets.orders.market
 
 import markets.MarketsTestKit
-import markets.tradables.Security
 import org.scalatest.{FeatureSpec, GivenWhenThen, Matchers}
 
 import scala.util.Random
@@ -52,19 +51,6 @@ class MarketAskOrderSpec extends FeatureSpec
       )
 
     }
-  }
-
-  feature("A MarketAskOrder should be able to split itself into two separate orders.") {
-
-    val askOrder = randomAskOrder(marketOrderProbability = 1.0, tradable = validTradable)
-
-    val filledQuantity = randomQuantity(upper=askOrder.quantity)
-    val residualQuantity = askOrder.quantity - filledQuantity
-    val (filledOrder, residualOrder) = askOrder.split(residualQuantity)
-
-    filledOrder.quantity should be(filledQuantity)
-    residualOrder.quantity should be(residualQuantity)
-
   }
 
 }

--- a/src/test/scala-2.11/markets/orders/market/MarketBidOrderSpec.scala
+++ b/src/test/scala-2.11/markets/orders/market/MarketBidOrderSpec.scala
@@ -16,7 +16,6 @@ limitations under the License.
 package markets.orders.market
 
 import markets.MarketsTestKit
-import markets.tradables.Security
 import org.scalatest.{FeatureSpec, GivenWhenThen, Matchers}
 
 import scala.util.Random
@@ -51,19 +50,6 @@ class MarketBidOrderSpec extends FeatureSpec
       )
 
     }
-  }
-
-  feature("A MarketBidOrder should be able to split itself into two separate orders.") {
-
-    val bidOrder = randomBidOrder(marketOrderProbability = 1.0, tradable = validTradable)
-
-    val filledQuantity = randomQuantity(upper=bidOrder.quantity)
-    val residualQuantity = bidOrder.quantity - filledQuantity
-    val (filledOrder, residualOrder) = bidOrder.split(residualQuantity)
-
-    filledOrder.quantity should be(filledQuantity)
-    residualOrder.quantity should be(residualQuantity)
-
   }
 
 }


### PR DESCRIPTION
Although we need to be able to split orders, whether or not all orders need to be splittable is an open question going to remove this method for now to make progress on new API easier.
