### PR TITLE
Optional non price criteria

### DIFF
--- a/src/main/scala-2.11/markets/tradables/orders/AdditionalCriteria.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/AdditionalCriteria.scala
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 ScalABM
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package markets.tradables.orders
+
+import markets.tradables.{LimitPrice, Tradable}
+
+
+/** Mixin trait defining additional, non-price criteria used to determine whether some `Tradable` is acceptable. */
+sealed trait AdditionalCriteria[-T <: Tradable] {
+  this: Tradable with LimitPrice with Predicate[T] =>
+
+  /** Additional, non-price criteria used to determine whether some `Tradable` is acceptable. */
+  def additionalCriteria: Option[(T) => Boolean]
+
+}
+
+
+/** Mixin trait used when there are no additional, non-price criteria needed to determine whether some `Tradable` is acceptable. */
+trait NoAdditionalCriteria[-T <: Tradable] extends AdditionalCriteria[T] {
+  this: Tradable with LimitPrice with Predicate[T] =>
+
+  /** Additional, non-price criteria used to determine whether some `Tradable` is acceptable. */
+  def additionalCriteria: Option[(T) => Boolean] = None
+
+}

--- a/src/main/scala-2.11/markets/tradables/orders/Predicate.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/Predicate.scala
@@ -28,4 +28,7 @@ trait Predicate[-T <: Tradable] {
     */
   def isAcceptable: T => Boolean
 
+  /** Non-price criteria used to determine whether some `Tradable` is an acceptable. */
+  def nonPriceCriteria: Option[(T) => Boolean]
+
 }

--- a/src/main/scala-2.11/markets/tradables/orders/Predicate.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/Predicate.scala
@@ -28,7 +28,4 @@ trait Predicate[-T <: Tradable] {
     */
   def isAcceptable: T => Boolean
 
-  /** Non-price criteria used to determine whether some `Tradable` is an acceptable. */
-  def nonPriceCriteria: Option[(T) => Boolean]
-
 }

--- a/src/main/scala-2.11/markets/tradables/orders/ask/LimitAskOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/ask/LimitAskOrder.scala
@@ -26,14 +26,14 @@ import markets.tradables.{LimitPrice, Tradable}
 trait LimitAskOrder extends AskOrder with LimitPrice with Predicate[BidOrder] {
 
   /** Non-price criteria used to determine whether some `BidOrder` is an acceptable match for a `LimitAskOrder`. */
-  def nonPriceCriteria: Option[(BidOrder) => Boolean]
+  def additionalCriteria: Option[(BidOrder) => Boolean]
 
   /** Boolean function used to determine whether some `BidOrder` is an acceptable match for a `LimitAskOrder`
     *
     * @return a boolean function that returns `true` if the `BidOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (BidOrder) => Boolean = nonPriceCriteria match {
-    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+  def isAcceptable: (BidOrder) => Boolean = additionalCriteria match {
+    case Some(nonPriceCriteria) => order => priceCriteria(order) && nonPriceCriteria(order)
     case None => order => priceCriteria(order)
   }
 
@@ -76,7 +76,7 @@ object LimitAskOrder {
     DefaultLimitAskOrder(issuer, limit, nonPriceCriteria, quantity, timestamp, tradable, uuid)
   }
 
-  private[this] case class DefaultLimitAskOrder(issuer: UUID, limit: Long, nonPriceCriteria: Option[(BidOrder) => Boolean],
+  private[this] case class DefaultLimitAskOrder(issuer: UUID, limit: Long, additionalCriteria: Option[(BidOrder) => Boolean],
                                                 quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends LimitAskOrder {
 

--- a/src/main/scala-2.11/markets/tradables/orders/ask/MarketAskOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/ask/MarketAskOrder.scala
@@ -26,14 +26,14 @@ import markets.tradables.Tradable
 trait MarketAskOrder extends AskOrder with MarketOrder with Predicate[BidOrder] {
 
   /** Non-price criteria used to determine whether some `BidOrder` is an acceptable match for a `MarketAskOrder`. */
-  def nonPriceCriteria: Option[(BidOrder) => Boolean]
+  def additionalCriteria: Option[(BidOrder) => Boolean]
 
   /** Boolean function used to determine whether some `BidOrder` is an acceptable match for a `MarketAskOrder`
     *
     * @return a boolean function that returns `true` if the `BidOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (BidOrder) => Boolean = nonPriceCriteria match {
-    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+  def isAcceptable: (BidOrder) => Boolean = additionalCriteria match {
+    case Some(nonPriceCriteria) => order => priceCriteria(order) && nonPriceCriteria(order)
     case None => order => priceCriteria(order)
   }
 
@@ -58,7 +58,7 @@ object MarketAskOrder {
   /** Default implementation of a `MarketAskOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
-    * @param nonPriceCriteria a function defining non-price criteria used to determine whether some `BidOrder` is an
+    * @param additionalCriteria a function defining non-price criteria used to determine whether some `BidOrder` is an
     *                         acceptable match for the `MarketAskOrder`.
     * @param quantity the number of units of the `tradable` for which the `MarketAskOrder` was issued.
     * @param timestamp the time at which the `MarketAskOrder` was issued.
@@ -66,7 +66,7 @@ object MarketAskOrder {
     * @param uuid the `UUID` of the `MarketAskOrder`.
     * @return an instance of a `MarketAskOrder`.
     */
-  private[this] case class DefaultMarketAskOrder(issuer: UUID, nonPriceCriteria: Option[(BidOrder) => Boolean],
+  private[this] case class DefaultMarketAskOrder(issuer: UUID, additionalCriteria: Option[(BidOrder) => Boolean],
                                                  quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends MarketAskOrder {
 

--- a/src/main/scala-2.11/markets/tradables/orders/ask/MarketAskOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/ask/MarketAskOrder.scala
@@ -25,11 +25,19 @@ import markets.tradables.Tradable
 /** Trait defining an order to sell some `Tradable` at any price. */
 trait MarketAskOrder extends AskOrder with MarketOrder with Predicate[BidOrder] {
 
+  /** Non-price criteria used to determine whether some `BidOrder` is an acceptable match for a `MarketAskOrder`. */
+  def nonPriceCriteria: Option[(BidOrder) => Boolean]
+
   /** Boolean function used to determine whether some `BidOrder` is an acceptable match for a `MarketAskOrder`
     *
     * @return a boolean function that returns `true` if the `BidOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (BidOrder) => Boolean = {
+  def isAcceptable: (BidOrder) => Boolean = nonPriceCriteria match {
+    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+    case None => order => priceCriteria(order)
+  }
+
+  protected def priceCriteria: (BidOrder) => Boolean = {
     case order @ (_: MarketBidOrder | _: LimitBidOrder) => order.tradable == this.tradable
     case _ => false
   }
@@ -42,26 +50,29 @@ object MarketAskOrder {
   /** By default, instances of `MarketAskOrder` are ordered based on `uuid` price from lowest to highest */
   implicit def ordering[A <: MarketAskOrder]: Ordering[A] = Order.ordering
 
-  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): MarketAskOrder = {
-    DefaultMarketAskOrder(issuer, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, nonPriceCriteria: Option[(BidOrder) => Boolean], quantity: Long, timestamp: Long,
+            tradable: Tradable, uuid: UUID): MarketAskOrder = {
+    DefaultMarketAskOrder(issuer, nonPriceCriteria, quantity, timestamp, tradable, uuid)
   }
 
   /** Default implementation of a `MarketAskOrder`.
     *
-    * @param issuer
-    * @param quantity
-    * @param timestamp
-    * @param tradable
-    * @param uuid
+    * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
+    * @param nonPriceCriteria a function defining non-price criteria used to determine whether some `BidOrder` is an
+    *                         acceptable match for the `MarketAskOrder`.
+    * @param quantity the number of units of the `tradable` for which the `MarketAskOrder` was issued.
+    * @param timestamp the time at which the `MarketAskOrder` was issued.
+    * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
+    * @param uuid the `UUID` of the `MarketAskOrder`.
+    * @return an instance of a `MarketAskOrder`.
     */
-  private[this] case class DefaultMarketAskOrder(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class DefaultMarketAskOrder(issuer: UUID, nonPriceCriteria: Option[(BidOrder) => Boolean],
+                                                 quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends MarketAskOrder {
 
-    /** Boolean function used to determine whether some `BidOrder` is an acceptable match for a `MarketAskOrder`
-      *
-      * @return a boolean function that returns `true` if the `BidOrder` is acceptable and `false` otherwise.
-      */
     override val isAcceptable: (BidOrder) => Boolean = super.isAcceptable
+
+    override protected val priceCriteria: (BidOrder) => Boolean = super.priceCriteria
 
   }
 

--- a/src/main/scala-2.11/markets/tradables/orders/bid/LimitBidOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/bid/LimitBidOrder.scala
@@ -26,14 +26,14 @@ import markets.tradables.{LimitPrice, Tradable}
 trait LimitBidOrder extends BidOrder with LimitPrice with Predicate[AskOrder] {
 
   /** Non-price criteria used to determine whether some `AskOrder` is an acceptable match for a `LimitBidOrder`. */
-  def nonPriceCriteria: Option[(AskOrder) => Boolean]
+  def additionalCriteria: Option[(AskOrder) => Boolean]
 
   /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `LimitBidOrder`
     *
     * @return a boolean function that returns `true` if the `AskOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (AskOrder) => Boolean = nonPriceCriteria match {
-    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+  def isAcceptable: (AskOrder) => Boolean = additionalCriteria match {
+    case Some(nonPriceCriteria) => order => priceCriteria(order) && nonPriceCriteria(order)
     case None => order => priceCriteria(order)
   }
 
@@ -76,7 +76,7 @@ object LimitBidOrder {
     DefaultLimitBidOrder(issuer, limit, nonPriceCriteria, quantity, timestamp, tradable, uuid)
   }
 
-  private[this] case class DefaultLimitBidOrder(issuer: UUID, limit: Long, nonPriceCriteria: Option[(AskOrder) => Boolean],
+  private[this] case class DefaultLimitBidOrder(issuer: UUID, limit: Long, additionalCriteria: Option[(AskOrder) => Boolean],
                                                 quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends LimitBidOrder {
 

--- a/src/main/scala-2.11/markets/tradables/orders/bid/LimitBidOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/bid/LimitBidOrder.scala
@@ -25,11 +25,19 @@ import markets.tradables.{LimitPrice, Tradable}
 /** Trait defining an order to buy some `Tradable` at a price less than or equal to some limit price. */
 trait LimitBidOrder extends BidOrder with LimitPrice with Predicate[AskOrder] {
 
+  /** Non-price criteria used to determine whether some `AskOrder` is an acceptable match for a `LimitBidOrder`. */
+  def nonPriceCriteria: Option[(AskOrder) => Boolean]
+
   /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `LimitBidOrder`
     *
     * @return a boolean function that returns `true` if the `AskOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (AskOrder) => Boolean = {
+  def isAcceptable: (AskOrder) => Boolean = nonPriceCriteria match {
+    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+    case None => order => priceCriteria(order)
+  }
+
+  protected def priceCriteria: (AskOrder) => Boolean = {
     case order: MarketAskOrder => order.tradable == this.tradable
     case order: LimitAskOrder => (order.tradable == this.tradable) && (this.limit >= order.limit)
     case _ => false
@@ -55,23 +63,26 @@ object LimitBidOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
     * @param limit the minimum price at which the `LimitBidOrder` can be executed.
+    * @param nonPriceCriteria a function defining non-price criteria used to determine whether some `AskOrder` is an
+    *                         acceptable match for the `LimitBidOrder`.
     * @param quantity the number of units of the `tradable` for which the `LimitBidOrder` was issued.
     * @param timestamp the time at which the `LimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
     * @param uuid the `UUID` of the `LimitBidOrder`.
     * @return an instance of a `LimitBidOrder`.
     */
-  def apply(issuer: UUID, limit: Long, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): LimitBidOrder = {
-    DefaultLimitBidOrder(issuer, limit, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Long, nonPriceCriteria: Option[(AskOrder) => Boolean], quantity: Long, timestamp: Long,
+            tradable: Tradable, uuid: UUID): LimitBidOrder = {
+    DefaultLimitBidOrder(issuer, limit, nonPriceCriteria, quantity, timestamp, tradable, uuid)
   }
 
-  private[this] case class DefaultLimitBidOrder(issuer: UUID, limit: Long, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class DefaultLimitBidOrder(issuer: UUID, limit: Long, nonPriceCriteria: Option[(AskOrder) => Boolean],
+                                                quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends LimitBidOrder {
-    /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `LimitBidOrder`
-      *
-      * @return a boolean function that returns `true` if the `AskOrder` is acceptable and `false` otherwise.
-      */
+
     override val isAcceptable: (AskOrder) => Boolean = super.isAcceptable
+
+    override protected val priceCriteria: (AskOrder) => Boolean = super.priceCriteria
 
   }
 

--- a/src/main/scala-2.11/markets/tradables/orders/bid/MarketBidOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/bid/MarketBidOrder.scala
@@ -25,11 +25,19 @@ import markets.tradables.Tradable
 /** Trait defining an order to buy some `Tradable` at any price. */
 trait MarketBidOrder extends BidOrder with MarketOrder with Predicate[AskOrder] {
 
+  /** Non-price criteria used to determine whether some `AskOrder` is an acceptable match for a `MarketBidOrder`. */
+  def nonPriceCriteria: Option[(AskOrder) => Boolean]
+
   /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `MarketBidOrder`
     *
     * @return a boolean function that returns `true` if the `AskOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (AskOrder) => Boolean = {
+  def isAcceptable: (AskOrder) => Boolean = nonPriceCriteria match {
+    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+    case None => order => priceCriteria(order)
+  }
+
+  protected def priceCriteria: (AskOrder) => Boolean = {
     case order @ (_: MarketAskOrder | _: LimitAskOrder) => order.tradable == this.tradable
     case _ => false
   }
@@ -41,18 +49,29 @@ object MarketBidOrder {
 
   implicit def ordering[B <: MarketBidOrder]: Ordering[B] = Order.ordering
 
-  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): MarketBidOrder = {
-    DefaultMarketBidOrder(issuer, quantity, timestamp, tradable, uuid)
+  /** Creates an instance of a `MarketBidOrder`.
+    *
+    * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
+    * @param nonPriceCriteria a function defining non-price criteria used to determine whether some `AskOrder` is an
+    *                         acceptable match for the `MarketBidOrder`.
+    * @param quantity the number of units of the `tradable` for which the `MarketBidOrder` was issued.
+    * @param timestamp the time at which the `MarketBidOrder` was issued.
+    * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
+    * @param uuid the `UUID` of the `MarketBidOrder`.
+    * @return an instance of a `MarketBidOrder`.
+    */
+  def apply(issuer: UUID, nonPriceCriteria: Option[(AskOrder) => Boolean], quantity: Long, timestamp: Long,
+            tradable: Tradable, uuid: UUID): MarketBidOrder = {
+    DefaultMarketBidOrder(issuer, nonPriceCriteria, quantity, timestamp, tradable, uuid)
   }
 
-  private[this] case class DefaultMarketBidOrder(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class DefaultMarketBidOrder(issuer: UUID, nonPriceCriteria: Option[(AskOrder) => Boolean],
+                                                 quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends MarketBidOrder {
 
-    /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `MarketBidOrder`
-      *
-      * @return a boolean function that returns `true` if the `AskOrder` is acceptable and `false` otherwise.
-      */
     override val isAcceptable: (AskOrder) => Boolean = super.isAcceptable
+
+    override protected val priceCriteria: (AskOrder) => Boolean = super.priceCriteria
 
   }
 

--- a/src/main/scala-2.11/markets/tradables/orders/bid/MarketBidOrder.scala
+++ b/src/main/scala-2.11/markets/tradables/orders/bid/MarketBidOrder.scala
@@ -26,14 +26,14 @@ import markets.tradables.Tradable
 trait MarketBidOrder extends BidOrder with MarketOrder with Predicate[AskOrder] {
 
   /** Non-price criteria used to determine whether some `AskOrder` is an acceptable match for a `MarketBidOrder`. */
-  def nonPriceCriteria: Option[(AskOrder) => Boolean]
+  def additionalCriteria: Option[(AskOrder) => Boolean]
 
   /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `MarketBidOrder`
     *
     * @return a boolean function that returns `true` if the `AskOrder` is acceptable and `false` otherwise.
     */
-  def isAcceptable: (AskOrder) => Boolean = nonPriceCriteria match {
-    case Some(additionalCriteria) => order => priceCriteria(order) && additionalCriteria(order)
+  def isAcceptable: (AskOrder) => Boolean = additionalCriteria match {
+    case Some(nonPriceCriteria) => order => priceCriteria(order) && nonPriceCriteria(order)
     case None => order => priceCriteria(order)
   }
 
@@ -65,7 +65,7 @@ object MarketBidOrder {
     DefaultMarketBidOrder(issuer, nonPriceCriteria, quantity, timestamp, tradable, uuid)
   }
 
-  private[this] case class DefaultMarketBidOrder(issuer: UUID, nonPriceCriteria: Option[(AskOrder) => Boolean],
+  private[this] case class DefaultMarketBidOrder(issuer: UUID, additionalCriteria: Option[(AskOrder) => Boolean],
                                                  quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
     extends MarketBidOrder {
 

--- a/src/test/scala-2.11/markets/tradables/orders/ask/TestLimitAskOrder.scala
+++ b/src/test/scala-2.11/markets/tradables/orders/ask/TestLimitAskOrder.scala
@@ -16,13 +16,13 @@ limitations under the License.
 package markets.tradables.orders.ask
 
 import markets.tradables.orders.bid.BidOrder
-import markets.tradables.orders.{RandomIssuer, Timestamp}
+import markets.tradables.orders.{NoAdditionalCriteria, RandomIssuer, Timestamp}
 import markets.tradables.{RandomUUID, Tradable}
 
 
 /** Concrete implementation of the `LimitAskOrder` trait for testing purposes. */
 case class TestLimitAskOrder(limit: Long, quantity: Long = 1, tradable: Tradable)
-  extends LimitAskOrder with RandomIssuer with Timestamp with RandomUUID {
+  extends LimitAskOrder with RandomIssuer with NoAdditionalCriteria[BidOrder] with Timestamp with RandomUUID {
 
   /** Boolean function used to determine whether some `BidOrder` is an acceptable match for a `LimitAskOrder`
     *

--- a/src/test/scala-2.11/markets/tradables/orders/bid/TestLimitBidOrder.scala
+++ b/src/test/scala-2.11/markets/tradables/orders/bid/TestLimitBidOrder.scala
@@ -16,13 +16,13 @@ limitations under the License.
 package markets.tradables.orders.bid
 
 import markets.tradables.orders.ask.AskOrder
-import markets.tradables.orders.{RandomIssuer, Timestamp}
+import markets.tradables.orders.{NoAdditionalCriteria, RandomIssuer, Timestamp}
 import markets.tradables.{RandomUUID, Tradable}
 
 
 /** Concrete implementation of the `LimitBidOrder` trait for testing purposes. */
 case class TestLimitBidOrder(limit: Long, quantity: Long = 1, tradable: Tradable)
-  extends LimitBidOrder with RandomIssuer with Timestamp with RandomUUID {
+  extends LimitBidOrder with RandomIssuer with NoAdditionalCriteria[AskOrder] with Timestamp with RandomUUID {
 
   /** Boolean function used to determine whether some `AskOrder` is an acceptable match for a `LimitBidOrder`
     *


### PR DESCRIPTION
In order to speed up execution of certain matching mechanisms it is important to be able to distinguish between price criteria and optional non-price criteria.  This PR cleanly separates the two types of criteria. 
