### PR TITLE
Added implementations of immediate or fill orders.

### DIFF
--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrder.scala
@@ -15,26 +15,75 @@ limitations under the License.
 */
 package org.economicsl.agora.markets.tradables.orders.ask
 
-import org.economicsl.agora.markets.tradables.LimitPrice
-import org.economicsl.agora.markets.tradables.orders.bid.BidOrder
+import java.util.UUID
+
+import org.economicsl.agora.markets.tradables.{LimitPrice, Price, Tradable}
+import org.economicsl.agora.markets.tradables.orders.bid.{BidOrder, LimitBidOrder}
 import org.economicsl.agora.markets.tradables.orders.{Persistent, PriceCriteria}
 
 
 /** Trait defining a `LimitAskOrder`. */
-trait LimitAskOrder extends AskOrder with LimitPrice with PriceCriteria[BidOrder with Persistent]
+trait LimitAskOrder extends AskOrder with LimitPrice with PriceCriteria[BidOrder with Persistent] {
+
+  require(Price.MinValue < limit && limit < Price.MaxValue, "A price value must be strictly positive and finite!")
+
+  def priceCriteria: (BidOrder with Persistent) => Boolean = {
+    case order: LimitBidOrder with Persistent => limit <= order.limit
+    case _ => false
+  }
+
+  def isAcceptable: (BidOrder with Persistent) => Boolean = {
+    order => (order.tradable == tradable) && priceCriteria(order)
+  }
+
+}
 
 
 /** Companion object for the `LimitAskOrder` trait.
   *
-  * Provides various orderings for `LimitAskOrder` instances.
+  * Provides various orderings for `LimitAskOrder` instances as well as a constructor for the default implementation
+  * of a `LimitAskOrder`.
   */
 object LimitAskOrder {
-
 
   /** By default, instances of `LimitAskOrder` are ordered based on `limit` price from lowest to highest */
   implicit def ordering[A <: LimitAskOrder]: Ordering[A] = LimitPrice.ordering
 
   /** The highest priority `LimitAskOrder` is the one with the lowest `limit` price. */
   def priority[A <: LimitAskOrder]: Ordering[A] = LimitPrice.ordering.reverse
+
+  /** Creates an instance of a `LimitAskOrder`.
+    *
+    * @param issuer the `UUID` of the actor that issued the `LimitAskOrder`.
+    * @param limit the minimum price at which the `LimitAskOrder` can be executed.
+    * @param quantity the number of units of the `tradable` for which the `LimitAskOrder` was issued.
+    * @param timestamp the time at which the `LimitAskOrder` was issued.
+    * @param tradable the `Tradable` for which the `LimitAskOrder` was issued.
+    * @param uuid the `UUID` of the `LimitAskOrder`.
+    * @return an instance of a `LimitAskOrder`.
+    * @note this `LimitAskOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `LimitAskOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `LimitAskOrder` to persist in an
+    *       `AskOrderBook` use a `PersistentLimitAskOrder`.
+    */
+  def apply(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): LimitAskOrder = {
+    DefaultImpl(issuer, limit, quantity, timestamp, tradable, uuid)
+  }
+
+
+  /** Class providing a default implementation of a `LimitAskOrder` suitable for use in securities market simulations.
+    *
+    * @param issuer the `UUID` of the actor that issued the `LimitAskOrder`.
+    * @param limit the minimum price at which the `LimitAskOrder` can be executed.
+    * @param quantity the number of units of the `tradable` for which the `LimitAskOrder` was issued.
+    * @param timestamp the time at which the `LimitAskOrder` was issued.
+    * @param tradable the `Tradable` for which the `LimitAskOrder` was issued.
+    * @param uuid the `UUID` of the `LimitAskOrder`.
+    * @return an instance of a `LimitAskOrder`.
+    * @note this `LimitAskOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `LimitAskOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `LimitAskOrder` to persist in an
+    *       `AskOrderBook` use a `PersistentLimitAskOrder`.
+    */
+  private[this] case class DefaultImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+    extends LimitAskOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrder.scala
@@ -25,8 +25,6 @@ import org.economicsl.agora.markets.tradables.orders.{Persistent, PriceCriteria}
 /** Trait defining a `LimitAskOrder`. */
 trait LimitAskOrder extends AskOrder with LimitPrice with PriceCriteria[BidOrder with Persistent] {
 
-  require(Price.MinValue < limit && limit < Price.MaxValue, "A price value must be strictly positive and finite!")
-
   def priceCriteria: (BidOrder with Persistent) => Boolean = {
     case order: LimitBidOrder with Persistent => limit <= order.limit
     case _ => false

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/MarketAskOrder.scala
@@ -15,14 +15,57 @@ limitations under the License.
 */
 package org.economicsl.agora.markets.tradables.orders.ask
 
-import org.economicsl.agora.markets.tradables.Price
+import java.util.UUID
+
+import org.economicsl.agora.markets.tradables.{Price, Tradable}
 import org.economicsl.agora.markets.tradables.orders.Persistent
 
 
 /** Trait defining a `MarketAskOrder`. */
 trait MarketAskOrder extends LimitAskOrder with Persistent {
 
-  /** An issuer of a `PersistentMarketAskOrder` is willing to sell for any positive `Price`. */
+  /** An issuer of a `MarketAskOrder` is willing to sell for any positive `Price`. */
   val limit = Price.MinValue
+
+}
+
+
+/** Companion object for the `MarketAskOrder` trait.
+  *
+  * Provides constructors for the default implementations of a `MarketAskOrder`.
+  */
+object MarketAskOrder {
+
+  /** Creates an instance of a `MarketAskOrder`.
+    *
+    * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
+    * @param quantity the number of units of the `tradable` for which the `MarketAskOrder` was issued.
+    * @param timestamp the time at which the `MarketAskOrder` was issued.
+    * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
+    * @param uuid the `UUID` of the `MarketAskOrder`.
+    * @return an instance of a `MarketAskOrder`.
+    * @note a `MarketAskOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `MarketAskOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `MarketAskOrder` to persist in an
+    *       `AskOrderBook` use a `PersistentMarketAskOrder`.
+    */
+  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): MarketAskOrder = {
+    DefaultImpl(issuer, quantity, timestamp, tradable, uuid)
+  }
+
+
+  /** Class providing a default implementation of a `MarketAskOrder` designed for use in securities market simulations.
+    *
+    * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
+    * @param quantity the number of units of the `tradable` for which the `MarketAskOrder` was issued.
+    * @param timestamp the time at which the `MarketAskOrder` was issued.
+    * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
+    * @param uuid the `UUID` of the `MarketAskOrder`.
+    * @return an instance of a `MarketAskOrder`.
+    * @note a `MarketAskOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `MarketAskOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `MarketAskOrder` to persist in an
+    *       `AskOrderBook` use a `PersistentMarketAskOrder`.
+    */
+  private[this] case class DefaultImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+    extends MarketAskOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentLimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentLimitAskOrder.scala
@@ -59,19 +59,6 @@ object PersistentLimitAskOrder {
     */
   private[this] case class DefaultImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable,
                                        uuid: UUID)
-    extends PersistentLimitAskOrder {
-
-    require(Price.MinValue < limit && limit < Price.MaxValue, "A price value must be strictly positive and finite!")
-
-    val priceCriteria: (BidOrder with Persistent) => Boolean = {
-      case order: LimitBidOrder with Persistent => limit <= order.limit
-      case _ => false
-    }
-
-    val isAcceptable: (BidOrder with Persistent) => Boolean = {
-      order => (order.tradable == tradable) && priceCriteria(order)
-    }
-
-  }
+    extends PersistentLimitAskOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentMarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentMarketAskOrder.scala
@@ -18,7 +18,6 @@ package org.economicsl.agora.markets.tradables.orders.ask
 import java.util.UUID
 
 import org.economicsl.agora.markets.tradables.orders.Persistent
-import org.economicsl.agora.markets.tradables.orders.bid.{BidOrder, LimitBidOrder}
 import org.economicsl.agora.markets.tradables.Tradable
 
 
@@ -56,17 +55,6 @@ object PersistentMarketAskOrder {
     * @return an instance of a `PersistentMarketAskOrder`.
     */
   private[this] case class DefaultImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
-    extends PersistentMarketAskOrder {
-
-    val priceCriteria: (BidOrder with Persistent) => Boolean = {
-      case order: LimitBidOrder with Persistent => limit <= order.limit
-      case _ => false
-    }
-
-    val isAcceptable: (BidOrder with Persistent) => Boolean = {
-      order => (order.tradable == tradable) && priceCriteria(order)
-    }
-
-  }
+    extends PersistentMarketAskOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrder.scala
@@ -16,18 +16,34 @@ limitations under the License.
 package org.economicsl.agora.markets.tradables.orders.bid
 
 
-import org.economicsl.agora.markets.tradables.orders.ask.AskOrder
+import java.util.UUID
+
+import org.economicsl.agora.markets.tradables.orders.ask.{AskOrder, LimitAskOrder}
 import org.economicsl.agora.markets.tradables.orders.{Persistent, PriceCriteria}
-import org.economicsl.agora.markets.tradables.LimitPrice
+import org.economicsl.agora.markets.tradables.{LimitPrice, Price, Tradable}
 
 
 /** Trait defining a `LimitBidOrder`. */
-trait LimitBidOrder extends BidOrder with LimitPrice with PriceCriteria[AskOrder with Persistent]
+trait LimitBidOrder extends BidOrder with LimitPrice with PriceCriteria[AskOrder with Persistent] {
+  
+  require(Price.MinValue < limit && limit < Price.MaxValue, "A price value must be strictly positive and finite!")
+
+  def priceCriteria: (AskOrder with Persistent) => Boolean = {
+    case order: LimitAskOrder with Persistent => limit >= order.limit
+    case _ => false
+  }
+
+  def isAcceptable: (AskOrder with Persistent) => Boolean = {
+    order => (order.tradable == tradable) && priceCriteria(order)
+  }
+  
+}
 
 
 /** Companion object for the `LimitBidOrder` trait.
   *
-  * The companion object defines various orderings for `LimitBidOrder` instances.
+  * The companion object defines various orderings for `LimitBidOrder` instances as well as a constructor for the
+  * default implementation of `LimitBidOrder`.
   */
 object LimitBidOrder {
 
@@ -36,5 +52,39 @@ object LimitBidOrder {
 
   /** The highest priority `LimitBidOrder` is the one with the highest `limit` price. */
   def priority[B <: LimitBidOrder]: Ordering[B] = LimitPrice.ordering
+
+  /** Creates an instance of a `LimitBidOrder`.
+    *
+    * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
+    * @param limit the minimum price at which the `LimitBidOrder` can be executed.
+    * @param quantity the number of units of the `tradable` for which the `LimitBidOrder` was issued.
+    * @param timestamp the time at which the `LimitBidOrder` was issued.
+    * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
+    * @param uuid the `UUID` of the `LimitBidOrder`.
+    * @return an instance of a `LimitBidOrder`.
+    * @note this `LimitBidOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `LimitBidOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `LimitBidOrder` to persist in an
+    *       `BidOrderBook` use a `PersistentLimitBidOrder`.
+    */
+  def apply(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): LimitBidOrder = {
+    DefaultImpl(issuer, limit, quantity, timestamp, tradable, uuid)
+  }
+
+
+  /** Class providing a default implementation of a `LimitBidOrder` suitable for use in securities market simulations.
+    *
+    * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
+    * @param limit the minimum price at which the `LimitBidOrder` can be executed.
+    * @param quantity the number of units of the `tradable` for which the `LimitBidOrder` was issued.
+    * @param timestamp the time at which the `LimitBidOrder` was issued.
+    * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
+    * @param uuid the `UUID` of the `LimitBidOrder`.
+    * @note this `LimitBidOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `LimitBidOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `LimitBidOrder` to persist in an
+    *       `BidOrderBook` use a `PersistentLimitBidOrder`.
+    */
+  private[this] case class DefaultImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable,
+                                       uuid: UUID)
+    extends LimitBidOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrder.scala
@@ -25,8 +25,6 @@ import org.economicsl.agora.markets.tradables.{LimitPrice, Price, Tradable}
 
 /** Trait defining a `LimitBidOrder`. */
 trait LimitBidOrder extends BidOrder with LimitPrice with PriceCriteria[AskOrder with Persistent] {
-  
-  require(Price.MinValue < limit && limit < Price.MaxValue, "A price value must be strictly positive and finite!")
 
   def priceCriteria: (AskOrder with Persistent) => Boolean = {
     case order: LimitAskOrder with Persistent => limit >= order.limit

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/MarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/MarketBidOrder.scala
@@ -16,7 +16,9 @@ limitations under the License.
 package org.economicsl.agora.markets.tradables.orders.bid
 
 
-import org.economicsl.agora.markets.tradables.Price
+import java.util.UUID
+
+import org.economicsl.agora.markets.tradables.{Price, Tradable}
 
 
 /** Trait defining a `MarketBidOrder`. */
@@ -24,5 +26,46 @@ trait MarketBidOrder extends LimitBidOrder {
 
   /** An issuer of a `MarketBidOrder` is willing to buy at any positive `Price`. */
   val limit = Price.MaxValue
+
+}
+
+
+/** Companion object for the `MarketBidOrder` trait.
+  *
+  * Provides constructors for the default implementations of a `MarketBidOrder`.
+  */
+object MarketBidOrder {
+
+  /** Creates an instance of a `MarketBidOrder`.
+    *
+    * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
+    * @param quantity the number of units of the `tradable` for which the `MarketBidOrder` was issued.
+    * @param timestamp the time at which the `MarketBidOrder` was issued.
+    * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
+    * @param uuid the `UUID` of the `MarketBidOrder`.
+    * @return an instance of a `MarketBidOrder`.
+    * @note a `MarketBidOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `MarketBidOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `MarketBidOrder` to persist in an
+    *       `BidOrderBook` use a `PersistentMarketBidOrder`.
+    */
+  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): MarketBidOrder = {
+    DefaultImpl(issuer, quantity, timestamp, tradable, uuid)
+  }
+
+
+  /** Class providing a default implementation of a `MarketBidOrder` designed for use in securities market simulations.
+    *
+    * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
+    * @param quantity the number of units of the `tradable` for which the `MarketBidOrder` was issued.
+    * @param timestamp the time at which the `MarketBidOrder` was issued.
+    * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
+    * @param uuid the `UUID` of the `MarketBidOrder`.
+    * @return an instance of a `MarketBidOrder`.
+    * @note a `MarketBidOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `MarketBidOrder` must be filled
+    *       (either partially or fully) immediately or be cancelled. If you want a `MarketBidOrder` to persist in an
+    *       `BidOrderBook` use a `PersistentMarketBidOrder`.
+    */
+  private[this] case class DefaultImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+    extends MarketBidOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentLimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentLimitBidOrder.scala
@@ -17,9 +17,8 @@ package org.economicsl.agora.markets.tradables.orders.bid
 
 import java.util.UUID
 
-import org.economicsl.agora.markets.tradables.orders.ask.{AskOrder, LimitAskOrder}
 import org.economicsl.agora.markets.tradables.orders.Persistent
-import org.economicsl.agora.markets.tradables.{LimitPrice, Price, Tradable}
+import org.economicsl.agora.markets.tradables.{Price, Tradable}
 
 
 /** Trait defining a type of `LimitBidOrder` that can be stored in a `BidOrderBook`. */
@@ -58,19 +57,6 @@ object PersistentLimitBidOrder {
     */
   private[this] case class DefaultImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable,
                                        uuid: UUID)
-    extends PersistentLimitBidOrder {
-
-    require(Price.MinValue < limit && limit < Price.MaxValue, "A price value must be strictly positive and finite!")
-
-    val priceCriteria: (AskOrder with Persistent) => Boolean = {
-      case order: LimitAskOrder with Persistent => limit >= order.limit
-      case _ => false
-    }
-
-    val isAcceptable: (AskOrder with Persistent) => Boolean = {
-      order => (order.tradable == tradable) && priceCriteria(order)
-    }
-
-  }
+    extends PersistentLimitBidOrder
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentMarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentMarketBidOrder.scala
@@ -18,7 +18,6 @@ package org.economicsl.agora.markets.tradables.orders.bid
 import java.util.UUID
 
 import org.economicsl.agora.markets.tradables.orders.Persistent
-import org.economicsl.agora.markets.tradables.orders.ask.{AskOrder, LimitAskOrder}
 import org.economicsl.agora.markets.tradables.Tradable
 
 
@@ -56,17 +55,6 @@ object PersistentMarketBidOrder {
     * @return an instance of a `PersistentMarketBidOrder`.
     */
   private[this] case class DefaultImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
-    extends PersistentMarketBidOrder {
-
-    val priceCriteria: (AskOrder with Persistent) => Boolean = {
-      case order: LimitAskOrder with Persistent => limit >= order.limit
-      case _ => false
-    }
-
-    val isAcceptable: (AskOrder with Persistent) => Boolean = {
-      order => (order.tradable == tradable) && priceCriteria(order)
-    }
-
-  }
+    extends PersistentMarketBidOrder
 
 }

--- a/src/test/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrderSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrderSpec.scala
@@ -35,23 +35,11 @@ class LimitAskOrderSpec extends FeatureSpec with GivenWhenThen with Matchers wit
 
     }
 
-    scenario("Creating a LimitAskOrder with zero price.") {
-
-      When("a LimitAskOrder with a zero price is constructed an exception is thrown.")
-
-      val zeroPrice = Price(0)
-      intercept[IllegalArgumentException](
-        orderGenerator.nextLimitAskOrder(zeroPrice, validTradable)
-      )
-
-    }
-
   }
 
   feature("A LimitAskOrder should be able to cross with other orders.") {
 
-    val askPrice = Price(100)
-    val askOrder = orderGenerator.nextLimitAskOrder(askPrice, validTradable)
+    val askOrder = orderGenerator.nextLimitAskOrder(validTradable)
 
     scenario("A LimitAskOrder should cross with any MarketBidOrder.") {
       val bidOrder = orderGenerator.nextMarketBidOrder(validTradable)
@@ -59,14 +47,14 @@ class LimitAskOrderSpec extends FeatureSpec with GivenWhenThen with Matchers wit
     }
 
     scenario("A LimitAskOrder should cross with any LimitBidOrder with a higher price.") {
-      val bidPrice = Price(105)
-      val bidOrder = orderGenerator.nextLimitBidOrder(bidPrice, validTradable)
+      val highPrice = Price(askOrder.limit.value + 1)
+      val bidOrder = orderGenerator.nextLimitBidOrder(highPrice, validTradable)
       assert(askOrder.isAcceptable(bidOrder))
     }
 
     scenario("A LimitAskOrder should not cross with any LimitBidOrder with a lower price.") {
-      val bidPrice = Price(95)
-      val bidOrder = orderGenerator.nextLimitBidOrder(bidPrice, validTradable)
+      val lowPrice = Price(askOrder.limit.value - 1)
+      val bidOrder = orderGenerator.nextLimitBidOrder(lowPrice, validTradable)
       assert(!askOrder.isAcceptable(bidOrder))
     }
 
@@ -74,6 +62,7 @@ class LimitAskOrderSpec extends FeatureSpec with GivenWhenThen with Matchers wit
       val bidOrder = orderGenerator.nextLimitBidOrder(invalidTradable)
       assert(!askOrder.isAcceptable(bidOrder))
     }
+
   }
 
 }

--- a/src/test/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrderSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrderSpec.scala
@@ -35,17 +35,6 @@ class LimitBidOrderSpec extends FeatureSpec with GivenWhenThen with Matchers wit
 
     }
 
-    scenario("Creating a LimitBidOrder with zero price.") {
-
-      When("a LimitBidOrder with a zero price is constructed an exception is thrown.")
-
-      val zeroPrice = Price(0)
-      intercept[IllegalArgumentException](
-        orderGenerator.nextLimitBidOrder(zeroPrice, validTradable)
-      )
-
-    }
-
   }
 
   feature("A LimitBidOrder should be able to cross with other orders.") {
@@ -57,14 +46,16 @@ class LimitBidOrderSpec extends FeatureSpec with GivenWhenThen with Matchers wit
       assert(bidOrder.isAcceptable(askOrder))
     }
 
-    scenario("A LimitBidOrder should cross with any LimitAskOrder with a higher price.") {
-      val askOrder = orderGenerator.nextLimitAskOrder(validTradable)
-      assert(bidOrder.isAcceptable(askOrder))
+    scenario("A LimitBidOrder should not cross with a LimitAskOrder with a higher price.") {
+      val highPrice = Price(bidOrder.limit.value + 1)
+      val askOrder = orderGenerator.nextLimitAskOrder(highPrice, validTradable)
+      assert(!bidOrder.isAcceptable(askOrder))
     }
 
-    scenario("A LimitBidOrder should not cross with any LimitAskOrder with a lower price.") {
+    scenario("A LimitBidOrder should cross with any LimitAskOrder with a lower price.") {
+      val lowPrice = Price(bidOrder.limit.value - 1)
       val askOrder = orderGenerator.nextLimitAskOrder(validTradable)
-      assert(!bidOrder.isAcceptable(askOrder))
+      assert(bidOrder.isAcceptable(askOrder))
     }
 
     scenario("A LimitBidOrder should not cross with any LimitAskOrder for another tradable.") {


### PR DESCRIPTION
Created default implementations for Limit and Market orders which serve are now semantically interpreted as "Immediate-Or-Cancel" orders...