### PR TITLE
Add clear method

### DIFF
--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/ExistingOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/ExistingOrders.scala
@@ -39,7 +39,7 @@ trait ExistingOrders[O <: Order with Persistent] extends auctions.orderbooks.Exi
     existingOrders += (order.uuid -> order)
   }
 
-  /** Remove all existing `Order` instances from the `OrderBook`. */
+  /** Remove all `Order` instances from the `OrderBook`. */
   def clear(): Unit = existingOrders.clear()
 
   /** Remove and return the head `Order` of the `OrderBook`.

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/ExistingOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/ExistingOrders.scala
@@ -39,6 +39,9 @@ trait ExistingOrders[O <: Order with Persistent] extends auctions.orderbooks.Exi
     existingOrders += (order.uuid -> order)
   }
 
+  /** Remove all existing `Order` instances from the `OrderBook`. */
+  def clear(): Unit = existingOrders.clear()
+
   /** Remove and return the head `Order` of the `OrderBook`.
     *
     * @return `None` if the `OrderBook` is empty; `Some(order)` otherwise.

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBook.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBook.scala
@@ -55,6 +55,18 @@ class OrderBook[O <: Order with Persistent](val tradable: Tradable) extends auct
     */
   def headOption: Option[O] = existingOrders.values.headOption
 
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` does not contain any `Order` instances; `false`, otherwise.
+    */
+  def isEmpty: Boolean = existingOrders.isEmpty
+
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` contains any `Order` instances; `false`, otherwise.
+    */
+  def nonEmpty: Boolean = existingOrders.nonEmpty
+
   /** Reduces the existing orders of this `OrderBook`, if any, using the specified associative binary operator.
     *
     * @param op an associative binary operator.

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrders.scala
@@ -39,7 +39,7 @@ trait SortedOrders[O <: Order with Persistent] extends auctions.orderbooks.Sorte
     require(order.tradable == tradable)
     existingOrders += (order.uuid -> order); sortedOrders.add(order)
   }
-  
+
   /** Remove all existing `Order` instances from the `OrderBook`. */
   override def clear(): Unit = {
     existingOrders.clear(); sortedOrders.clear()
@@ -59,6 +59,18 @@ trait SortedOrders[O <: Order with Persistent] extends auctions.orderbooks.Sorte
     * @note the head `Order` of the `SortedOrderBook` is the head `Order` of the underlying `sortedOrders`.
     */
   override def headOption: Option[O] = sortedOrders.headOption
+
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` does not contain any `Order` instances; `false`, otherwise.
+    */
+  override def isEmpty: Boolean = existingOrders.isEmpty && sortedOrders.isEmpty
+
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` contains any `Order` instances; `false`, otherwise.
+    */
+  override def nonEmpty: Boolean = existingOrders.nonEmpty && sortedOrders.nonEmpty
 
   /** Remove and return an existing `Order` from the `SortedOrderBook`.
     *

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrders.scala
@@ -39,6 +39,11 @@ trait SortedOrders[O <: Order with Persistent] extends auctions.orderbooks.Sorte
     require(order.tradable == tradable)
     existingOrders += (order.uuid -> order); sortedOrders.add(order)
   }
+  
+  /** Remove all existing `Order` instances from the `OrderBook`. */
+  override def clear(): Unit = {
+    existingOrders.clear(); sortedOrders.clear()
+  }
 
   /** Find the first `Order` in the `SortedOrderBook` that satisfies the given predicate.
     *

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/ExistingOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/ExistingOrders.scala
@@ -40,6 +40,9 @@ trait ExistingOrders[O <: Order with Persistent, +CC <: parallel.mutable.ParMap[
     existingOrders += (order.uuid -> order)
   }
 
+  /** Remove all `Order` instances from the `OrderBook`. */
+  def clear(): Unit = existingOrders.clear()
+
   /** Remove and return the head `Order` of the `OrderBook`.
     *
     * @return `None` if the `OrderBook` is empty; `Some(order)` otherwise.

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBook.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBook.scala
@@ -60,6 +60,19 @@ class OrderBook[O <: Order with Persistent](val tradable: Tradable) extends auct
     */
   def headOption: Option[O] = existingOrders.values.headOption
 
+
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` does not contain any `Order` instances; `false`, otherwise.
+    */
+  def isEmpty: Boolean = existingOrders.isEmpty
+
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` contains any `Order` instances; `false`, otherwise.
+    */
+  def nonEmpty: Boolean = existingOrders.nonEmpty
+
   /** Reduces the existing orders of this `OrderBook`, if any, using the specified associative binary operator.
     *
     * @param op an associative binary operator.

--- a/src/main/scala/org/economicsl/agora/markets/auctions/orderbooks/OrderBookLike.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/orderbooks/OrderBookLike.scala
@@ -43,6 +43,18 @@ trait OrderBookLike[+O <: Order with Persistent] {
     */
   def headOption: Option[O]
 
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` does not contain any `Order` instances; `false`, otherwise.
+    */
+  def isEmpty: Boolean
+
+  /** Boolean flag indicating whether or not the `OrderBook` contains `Order` instances.
+    *
+    * @return `true`, if the `OrderBook` contains any `Order` instances; `false`, otherwise.
+    */
+  def nonEmpty: Boolean
+
   /** Reduces the existing orders of this `OrderBook`, if any, using the specified associative binary operator.
     *
     * @param op an associative binary operator.

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBookSpec.scala
@@ -54,6 +54,20 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitAskOrder with
 
   }
 
+  feature(s"A mutable OrderBook should be able to clear its existing orders.") {
+
+    val orderBook = orderBookFactory(validTradable)
+
+    scenario("Clearing existing orders from an OrderBook.") {
+      val numberOrders = 10
+      val orders = for { i <- 1 to numberOrders} yield orderGenerator.nextLimitAskOrder(validTradable)
+      orders.foreach(order => orderBook.add(order))
+      orderBook.clear()
+      orderBook.isEmpty should be(true)
+    }
+
+  }
+
   feature(s"A mutable.OrderBook should be able to find an AskOrder.") {
 
     scenario(s"Finding an existing LimitAskOrder with Persistent in an mutable.OrderBook.") {

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookSpec.scala
@@ -64,7 +64,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
     }
 
   }
-  
+
   feature(s"A mutable SortedOrderBook should be able to add bid orders.") {
 
     val orderBook = orderBookFactory(validTradable)

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookSpec.scala
@@ -27,9 +27,9 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
     SortedOrderBook[LimitBidOrder with Persistent](tradable)
   }
 
-  feature(s"A mutable.SortedOrderBook should be able to find a BidOrder.") {
+  feature(s"A mutableSortedOrderBook should be able to find a BidOrder.") {
 
-    scenario(s"Finding an existing LimitBidOrder in an mutable.SortedOrderBook.") {
+    scenario(s"Finding an existing LimitBidOrder in an mutable SortedOrderBook.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val marketOrder = orderGenerator.nextMarketBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -39,7 +39,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
       foundOrder should be(Some(limitOrder))
     }
 
-    scenario(s"Finding a MarketBidOrder in an mutable.SortedOrderBook containing only LimitBidOrder instances.") {
+    scenario(s"Finding a MarketBidOrder in an mutable SortedOrderBook containing only LimitBidOrder instances.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val anotherLimitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -51,19 +51,32 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
 
   }
 
-
-  feature(s"A mutable.SortedOrderBook should be able to add bid orders.") {
+  feature(s"A mutable OrderBook should be able to clear its existing orders.") {
 
     val orderBook = orderBookFactory(validTradable)
 
-    scenario(s"Adding a valid bid order to a mutable.SortedOrderBook.") {
+    scenario("Clearing existing orders from a SortedOrderBook.") {
+      val numberOrders = 10
+      val orders = for { i <- 1 to numberOrders} yield orderGenerator.nextLimitBidOrder(validTradable)
+      orders.foreach(order => orderBook.add(order))
+      orderBook.clear()
+      orderBook.isEmpty should be(true)
+    }
+
+  }
+  
+  feature(s"A mutable SortedOrderBook should be able to add bid orders.") {
+
+    val orderBook = orderBookFactory(validTradable)
+
+    scenario(s"Adding a valid bid order to a mutable SortedOrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       orderBook.add(order)
       orderBook.headOption should be(Some(order))
       orderBook.existingOrders.headOption should be(Some((order.uuid, order)))
     }
 
-    scenario(s"Adding an invalid bid order to a mutable.SortedOrderBook.") {
+    scenario(s"Adding an invalid bid order to a mutable SortedOrderBook.") {
       val invalidOrder = orderGenerator.nextLimitBidOrder(invalidTradable)
       intercept[IllegalArgumentException] {
         orderBook.add(invalidOrder)
@@ -72,9 +85,9 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
 
   }
 
-  feature(s"A mutable.SortedOrderBook should be able to remove the head BidOrder.") {
+  feature(s"A mutable SortedOrderBook should be able to remove the head BidOrder.") {
 
-    scenario(s"Removing the head BidOrder from a mutable.SortedOrderBook.") {
+    scenario(s"Removing the head BidOrder from a mutable SortedOrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
@@ -84,7 +97,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
       orderBook.existingOrders.headOption should be(None)
     }
 
-    scenario(s"Removing the head BidOrder from an empty mutable.SortedOrderBook.") {
+    scenario(s"Removing the head BidOrder from an empty mutable SortedOrderBook.") {
       val orderBook = orderBookFactory(validTradable)
       val removedOrder = orderBook.remove()  // note that order has not been added!
       removedOrder should be(None)
@@ -94,9 +107,9 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
 
   }
 
-  feature(s"A mutable.SortedOrderBook should be able to remove bid orders.") {
+  feature(s"A mutable SortedOrderBook should be able to remove bid orders.") {
 
-    scenario(s"Removing an existing bid order from a mutable.SortedOrderBook.") {
+    scenario(s"Removing an existing bid order from a mutable SortedOrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
@@ -106,7 +119,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
       orderBook.existingOrders.headOption should be(None)
     }
 
-    scenario(s"Removing a bid order from an empty mutable.SortedOrderBook.") {
+    scenario(s"Removing a bid order from an empty mutable SortedOrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       val removedOrder = orderBook.remove(order.uuid)  // note that order has not been added!
@@ -117,9 +130,9 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
 
   }
 
-  feature(s"A mutable.SortedOrderBook should be able to filter its existingOrders.") {
+  feature(s"A mutable SortedOrderBook should be able to filter its existingOrders.") {
 
-    scenario(s"Finding all existing MarketBidOrder instances an mutable.SortedOrderBook.") {
+    scenario(s"Finding all existing MarketBidOrder instances an mutable SortedOrderBook.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val marketOrder = orderGenerator.nextMarketBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -129,7 +142,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
       filteredOrders should be(Some(Iterable(marketOrder)))
     }
 
-    scenario(s"Finding all MarketBidOrder in an mutable.SortedOrderBook containing only LimitBidOrder instances.") {
+    scenario(s"Finding all MarketBidOrder in an mutable SortedOrderBook containing only LimitBidOrder instances.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val anotherLimitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -141,7 +154,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
 
   }
 
-  feature(s"A mutable.SortedOrderBook should maintain sorting on price.") {
+  feature(s"A mutable SortedOrderBook should maintain sorting on price.") {
 
     scenario(s"MarketBidOrder should take priority over LimitBidOrder.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBookSpec.scala
@@ -27,25 +27,25 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
     OrderBook[LimitBidOrder with Persistent](tradable)
   }
 
-  feature("A mutable.OrderBook should be able to be built from specified type parameters.") {
+  feature("A parallel, mutable OrderBook should be able to be built from specified type parameters.") {
 
-    scenario("Creating a mutable.OrderBook using generic constructor.") {
+    scenario("Creating a parallel, mutable OrderBook using generic constructor.") {
       val orderBook = orderBookFactory(validTradable)
       assert(orderBook.isInstanceOf[OrderBook[LimitBidOrder with Persistent]])
     }
   }
 
-  feature(s"A mutable.OrderBook should be able to add a BidOrder.") {
+  feature(s"A parallel, mutable OrderBook should be able to add a BidOrder.") {
 
     val orderBook = orderBookFactory(validTradable)
 
-    scenario(s"Adding a valid bid order to an mutable.OrderBook.") {
+    scenario(s"Adding a valid bid order to an parallel, mutable OrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       orderBook.add(order)
       orderBook.headOption should be(Some(order))
     }
 
-    scenario(s"Adding an invalid bid order to an mutable.OrderBook.") {
+    scenario(s"Adding an invalid bid order to an parallel, mutable OrderBook.") {
       val invalidOrder = orderGenerator.nextLimitBidOrder(invalidTradable)
       intercept[IllegalArgumentException] {
         orderBook.add(invalidOrder)
@@ -54,9 +54,23 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
 
   }
 
-  feature(s"A mutable.OrderBook should be able to find a BidOrder.") {
+  feature(s"A parallel, mutable OrderBook should be able to clear its existing orders.") {
 
-    scenario(s"Finding an existing LimitBidOrder in an mutable.OrderBook.") {
+    val orderBook = orderBookFactory(validTradable)
+
+    scenario("Clearing existing orders from an OrderBook.") {
+      val numberOrders = 10
+      val orders = for { i <- 1 to numberOrders} yield orderGenerator.nextLimitBidOrder(validTradable)
+      orders.foreach(order => orderBook.add(order))
+      orderBook.clear()
+      orderBook.isEmpty should be(true)
+    }
+
+  }
+
+  feature(s"A parallel, mutable OrderBook should be able to find a BidOrder.") {
+
+    scenario(s"Finding an existing LimitBidOrder in an parallel, mutable OrderBook.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val marketOrder = orderGenerator.nextMarketBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -66,7 +80,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
       foundOrder should be(Some(limitOrder))
     }
 
-    scenario(s"Finding a MarketBidOrder in an mutable.OrderBook containing only LimitBidOrder instances.") {
+    scenario(s"Finding a MarketBidOrder in an parallel, mutable OrderBook containing only LimitBidOrder instances.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val anotherLimitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -78,9 +92,9 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
 
   }
 
-  feature(s"A mutable.OrderBook should be able to remove the head BidOrder.") {
+  feature(s"A parallel, mutable OrderBook should be able to remove the head BidOrder.") {
 
-    scenario(s"Removing the head BidOrder from an mutable.OrderBook.") {
+    scenario(s"Removing the head BidOrder from an parallel, mutable OrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
@@ -89,7 +103,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
       orderBook.headOption should be(None)
     }
 
-    scenario(s"Removing the head BidOrder from an empty mutable.OrderBook.") {
+    scenario(s"Removing the head BidOrder from an empty parallel, mutable OrderBook.") {
       val orderBook = orderBookFactory(validTradable)
       val removedOrder = orderBook.remove()  // note that order has not been added!
       removedOrder should be(None)
@@ -98,9 +112,9 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
 
   }
 
-  feature(s"A mutable.OrderBook should be able to remove a BidOrder.") {
+  feature(s"A parallel, mutable OrderBook should be able to remove a BidOrder.") {
 
-    scenario(s"Removing an existing bid order from an mutable.OrderBook.") {
+    scenario(s"Removing an existing bid order from an parallel, mutable OrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
@@ -109,7 +123,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
       orderBook.headOption should be(None)
     }
 
-    scenario(s"Removing a bid order from an empty mutable.OrderBook.") {
+    scenario(s"Removing a bid order from an empty parallel, mutable OrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       val removedOrder = orderBook.remove(order.uuid)  // note that order has not been added!
@@ -119,9 +133,9 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
 
   }
 
-  feature(s"A mutable.OrderBook should be able to filter its existingOrders.") {
+  feature(s"A parallel, mutable OrderBook should be able to filter its existingOrders.") {
 
-    scenario(s"Finding all existing MarketBidOrder instances an mutable.OrderBook.") {
+    scenario(s"Finding all existing MarketBidOrder instances an parallel, mutable OrderBook.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val marketOrder = orderGenerator.nextMarketBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
@@ -131,7 +145,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
       filteredOrders should be(Some(Iterable(marketOrder)))
     }
 
-    scenario(s"Finding all MarketBidOrder in an mutable.OrderBook containing only LimitBidOrder instances.") {
+    scenario(s"Finding all MarketBidOrder in an parallel, mutable OrderBook containing only LimitBidOrder instances.") {
       val limitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val anotherLimitOrder = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)


### PR DESCRIPTION
Need to be able to clear order books.  Currently clearing an order book simply removes all of the orders and does notify market participants or anything fancy...