### PR TITLE
Added a FindMarketClearingPrice rule.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,10 @@ lazy val commonSettings = Seq(
   organizationName := "EconomicSL",
   organizationHomepage := Some(url("https://economicsl.github.io/")),
   coverallsTokenFile := Some(".coveralls.token"),
+  libraryDependencies ++= Seq(
+    "com.typesafe" % "config" % "1.3.1",
+    "org.apache.commons" % "commons-math3" % "3.6.1"
+  ),
   resolvers ++= Seq(
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
@@ -34,8 +38,7 @@ lazy val core = (project in file(".")).
   settings(
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.1",
-      "org.scalatest" %% "scalatest" % "3.0.1" % "functional, test",
-      "org.apache.commons" % "commons-math3" % "3.6.1" % "functional, test"
+      "org.scalatest" %% "scalatest" % "3.0.1" % "functional, test"
     ),
     parallelExecution in Functional := false
   ).

--- a/src/main/scala/org/economicsl/agora/markets/auctions/matching/FindMostPreferredOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/matching/FindMostPreferredOrder.scala
@@ -35,7 +35,7 @@ class FindMostPreferredOrder[-O1 <: Order with Operator[O2], O2 <: Order with Pe
     * @note Worst case performance of this matching function is `O(n)` where `n` is the number of `Order` instances
     *       contained in the `orderBook`.
     */
-  def apply(order: O1, orderBook: OrderBookLike[O2]): Option[O2] = orderBook.reduce(order.operator)
+  def apply(order: O1, orderBook: OrderBookLike[O2]): Option[O2] = orderBook.reduceOption(order.operator)
 
 }
 

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBookLike.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBookLike.scala
@@ -61,6 +61,14 @@ trait OrderBookLike[O <: Order with Persistent] extends auctions.orderbooks.Orde
     */
   def nonEmpty: Boolean = existingOrders.nonEmpty
 
+  /** Applies a binary operator to a start value and all existing orders of the `OrderBook`, going left to right.
+    *
+    * @tparam P the return type of the binary operator
+    * @note might return different results for different runs, unless the existing orders are sorted or the operator is
+    *       associative and commutative.
+    */
+  def foldLeft[P](z: P)(op: (P, O) => P): P = existingOrders.values.foldLeft(z)(op)
+
   /** Reduces the existing orders of this `OrderBook`, if any, using the specified associative binary operator.
     *
     * @param op an associative binary operator.
@@ -68,7 +76,7 @@ trait OrderBookLike[O <: Order with Persistent] extends auctions.orderbooks.Orde
     *         `OrderBook` otherwise.
     * @note reducing the existing orders of an `OrderBook` is an `O(n)` operation.
     */
-  def reduce[O1 >: O](op: (O1, O1) => O1): Option[O1] = existingOrders.values.reduceOption(op)
+  def reduceOption[T >: O](op: (T, T) => T): Option[T] = existingOrders.values.reduceOption(op)
 
   /** Return the number of existing `Order` instances contained in the `OrderBook`. */
   def size: Int = existingOrders.size

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBook.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBook.scala
@@ -73,6 +73,15 @@ class OrderBook[O <: Order with Persistent](val tradable: Tradable) extends auct
     */
   def nonEmpty: Boolean = existingOrders.nonEmpty
 
+
+  /** Applies a binary operator to a start value and all existing orders of the `OrderBook`, going left to right.
+    *
+    * @tparam P the return type of the binary operator
+    * @note might return different results for different runs, unless the existing orders are sorted or the operator is
+    *       associative and commutative.
+    */
+  def foldLeft[P](z: P)(op: (P, O) => P): P = existingOrders.values.foldLeft(z)(op)
+
   /** Reduces the existing orders of this `OrderBook`, if any, using the specified associative binary operator.
     *
     * @param op an associative binary operator.
@@ -80,7 +89,7 @@ class OrderBook[O <: Order with Persistent](val tradable: Tradable) extends auct
     *         `OrderBook` otherwise.
     * @note reducing the existing orders of an `OrderBook` is an `O(n)` operation.
     */
-  def reduce[O1 >: O](op: (O1, O1) => O1): Option[O1] = existingOrders.values.reduceOption(op)
+  def reduceOption[O1 >: O](op: (O1, O1) => O1): Option[O1] = existingOrders.values.reduceOption(op)
 
   /* Protected at package-level for testing. */
   protected[orderbooks] val existingOrders = parallel.mutable.ParHashMap.empty[UUID, O]

--- a/src/main/scala/org/economicsl/agora/markets/auctions/orderbooks/OrderBookLike.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/orderbooks/OrderBookLike.scala
@@ -55,6 +55,14 @@ trait OrderBookLike[+O <: Order with Persistent] {
     */
   def nonEmpty: Boolean
 
+  /** Applies a binary operator to a start value and all existing orders of the `OrderBook`, going left to right.
+    *
+    * @tparam P the return type of the binary operator
+    * @note might return different results for different runs, unless the existing orders are sorted or the operator is
+    *       associative and commutative.
+    */
+  def foldLeft[P](z: P)(op: (P, O) => P): P
+
   /** Reduces the existing orders of this `OrderBook`, if any, using the specified associative binary operator.
     *
     * @param op an associative binary operator.
@@ -63,6 +71,6 @@ trait OrderBookLike[+O <: Order with Persistent] {
     * @note reducing the existing orders of an `OrderBook` is an `O(n)` operation. The order in which operations are
     *       performed on elements is unspecified and may be nondeterministic depending on the type of `OrderBook`.
     */
-  def reduce[O1 >: O](op: (O1, O1) => O1): Option[O1]
+  def reduceOption[T >: O](op: (T, T) => T): Option[T]
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/auctions/package.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/package.scala
@@ -15,10 +15,25 @@ limitations under the License.
 */
 package org.economicsl.agora.markets
 
+import org.apache.commons.math3.analysis.solvers.AllowedSolution
+
 
 /** Classes for modeling auction mechanisms.
   *
   * Key high-level abstraction: Auction mechanisms combine a matching rule with a pricing rule.  Auction mechanisms can
   * be either continuous or periodic.
   */
-package object auctions
+package object auctions {
+
+  /** Class implemented a simple configuration object for a non-linear equation solver. */
+  case class BrentSolverConfig(maxEvaluations: Int,
+                               min: Double,
+                               max: Double,
+                               startValue: Double,
+                               allowedSolution: AllowedSolution,
+                               relativeAccuracy: Double,
+                               absoluteAccuracy: Double,
+                               functionValueAccuracy: Double,
+                               maximalOrder: Int)
+
+}

--- a/src/main/scala/org/economicsl/agora/markets/auctions/pricing/FindMarketClearingPrice.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/pricing/FindMarketClearingPrice.scala
@@ -1,0 +1,65 @@
+package org.economicsl.agora.markets.auctions.pricing
+
+import org.economicsl.agora.markets.auctions.BrentSolverConfig
+import org.economicsl.agora.markets.auctions.mutable.orderbooks.{AskOrderBook, BidOrderBook}
+import org.economicsl.agora.markets.tradables.Price
+import org.economicsl.agora.markets.tradables.orders.ask.SupplyFunction
+import org.economicsl.agora.markets.tradables.orders.bid.DemandFunction
+
+import org.apache.commons.math3.analysis.UnivariateFunction
+import org.apache.commons.math3.analysis.solvers.BracketingNthOrderBrentSolver
+
+
+class FindMarketClearingPrice[AB <: AskOrderBook[SupplyFunction], BB <: BidOrderBook[DemandFunction]]
+                             (config: BrentSolverConfig, initialValue: Double)
+  extends UniformPricingRule[SupplyFunction, AB, DemandFunction, BB]{
+
+  def apply(askOrderBook: AB, bidOrderBook: BB): Price = {
+    val F = ExcessDemand(askOrderBook, bidOrderBook)
+    currentValue = solver.solve(config.maxEvaluations, F, config.min, config.max, config.startValue, config.allowedSolution)
+    Price(currentValue)
+  }
+
+  /** Computes the aggregate demand at the current price.
+    *
+    * @param bidOrderBook a `BidOrderBook` containing `DemandFunction` instances.
+    * @param current the `Price` for which each individual demand should be be computed.
+    * @return the total quantity of demand.
+    * @note computed aggregate demand is an `O(n)` operation where `n` is the `size` of the `bidOrderBook`.
+    */
+  private[this] def aggregateDemand(bidOrderBook: BB, current: Price): Double = {
+    bidOrderBook.foldLeft(0.0)((demand, order) => demand + order.demand(current))
+  }
+
+  /** Computes the aggregate supply at the current price.
+    *
+    * @param askOrderBook an `AskOrderBook` containing `SupplyFunction` instances.
+    * @param current the `Price` for which each individual supply should be be computed.
+    * @return the total quantity of supply.
+    * @note computed aggregate supply is an `O(n)` operation where `n` is the `size` of the `askOrderBook`.
+    */
+  private[this] def aggregateSupply(askOrderBook: AB, current: Price): Double = {
+    askOrderBook.foldLeft(0.0)((supply, order) => supply + order.supply(current))
+  }
+
+  private[this] val solver = {
+    new BracketingNthOrderBrentSolver(config.relativeAccuracy, config.absoluteAccuracy, config.functionValueAccuracy, config.maximalOrder)
+  }
+
+  /** Caches the most recently computed value of the price which is used to provide a "hot start" to the solver. */
+  @volatile private[this] var currentValue = initialValue
+
+  /** Class defining an excess demand function the root of which is the market clearing price.
+    *
+    * @param askOrderBook an `AskOrderBook` containing `SupplyFunction` instances.
+    * @param bidOrderBook a `BidOrderBook` containing `DemandFunction` instances.
+    */
+  private[this] case class ExcessDemand(askOrderBook: AB, bidOrderBook: BB) extends UnivariateFunction {
+
+    def value(x: Double): Double = {
+      aggregateDemand(bidOrderBook, Price(x)) - aggregateSupply(askOrderBook, Price(x))
+    }
+
+  }
+
+}

--- a/src/main/scala/org/economicsl/agora/markets/auctions/pricing/UniformPricingRule.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/pricing/UniformPricingRule.scala
@@ -1,0 +1,13 @@
+package org.economicsl.agora.markets.auctions.pricing
+
+import org.economicsl.agora.markets.auctions.mutable.orderbooks.{AskOrderBook, BidOrderBook}
+import org.economicsl.agora.markets.tradables.Price
+import org.economicsl.agora.markets.tradables.orders.Persistent
+import org.economicsl.agora.markets.tradables.orders.ask.AskOrder
+import org.economicsl.agora.markets.tradables.orders.bid.BidOrder
+
+
+/** Trait defining a uniform pricing rule. */
+trait UniformPricingRule[A <: AskOrder with Persistent, AB <: AskOrderBook[A],
+                         B <: BidOrder with Persistent, BB <: BidOrderBook[B]]
+  extends ((AB, BB) => Price)

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ExcessDemandFunction.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ExcessDemandFunction.scala
@@ -1,0 +1,28 @@
+/*
+Copyright 2016 ScalABM
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.agora.markets.tradables.orders
+
+import org.economicsl.agora.markets.tradables.Price
+
+
+/** Mixin trait defining an `ExcessDemandFunction`. */
+trait ExcessDemandFunction {
+  this: Order with Persistent =>
+
+  /** Quantity demanded/supplied as a function of the `Price`. */
+  def excessDemand: (Price) => Long
+
+}

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/SupplyFunction.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/SupplyFunction.scala
@@ -1,0 +1,28 @@
+/*
+Copyright 2016 ScalABM
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.agora.markets.tradables.orders.ask
+
+import org.economicsl.agora.markets.tradables.Price
+import org.economicsl.agora.markets.tradables.orders.Persistent
+
+
+/** Trait defining the interface for a `SupplyFunction`. */
+trait SupplyFunction extends AskOrder with Persistent {
+
+  /** Quantity supplied as a function of the `Price`. */
+  def supply: (Price) => Double
+
+}

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/DemandFunction.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/DemandFunction.scala
@@ -1,0 +1,28 @@
+/*
+Copyright 2016 ScalABM
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.agora.markets.tradables.orders.bid
+
+import org.economicsl.agora.markets.tradables.Price
+import org.economicsl.agora.markets.tradables.orders.Persistent
+
+
+/** Mixin trait defining a `DemandFunction`. */
+trait DemandFunction extends BidOrder with Persistent {
+
+  /** Quantity demanded as a function of the `Price`. */
+  def demand: (Price) => Double
+
+}


### PR DESCRIPTION
Example of a uniform pricing function that computes the market clearing price given two order books.  Assumes that traders provide supply or demand functions.