### PR TITLE
Remove timestamp from order

### DIFF
--- a/src/functional/scala/org/economicsl/agora/markets/UniformRandomTradingRule.scala
+++ b/src/functional/scala/org/economicsl/agora/markets/UniformRandomTradingRule.scala
@@ -29,11 +29,11 @@ class UniformRandomTradingRule(askOrderProbability: Double, issuer: UUID, prng: 
 
   def apply(tradable: Tradable): Either[LimitAskOrder with SingleUnit, LimitBidOrder with SingleUnit] = {
     if (prng.nextDouble() <= askOrderProbability) {
-      val (limit, timestamp) = (Price(askPriceDistribution.sample()), System.currentTimeMillis())
-      Left(PersistentLimitAskOrder(issuer, limit, timestamp, tradable, UUID.randomUUID()))
+      val limit = Price(askPriceDistribution.sample())
+      Left(PersistentLimitAskOrder(issuer, limit, tradable, UUID.randomUUID()))
     } else {
-      val (limit, timestamp) = (Price(bidPriceDistribution.sample()), System.currentTimeMillis())
-      Right(PersistentLimitBidOrder(issuer, limit, timestamp, tradable, UUID.randomUUID()))
+      val limit = Price(bidPriceDistribution.sample())
+      Right(PersistentLimitBidOrder(issuer, limit, tradable, UUID.randomUUID()))
     }
   }
 

--- a/src/functional/scala/org/economicsl/agora/markets/auctions/mutable/continuous/BuyersBidDoubleAuctionSimulation.scala
+++ b/src/functional/scala/org/economicsl/agora/markets/auctions/mutable/continuous/BuyersBidDoubleAuctionSimulation.scala
@@ -111,7 +111,7 @@ object BuyersBidDoubleAuctionSimulation extends App {
 
     def apply(tradable: Tradable): PersistentLimitBidOrder with SingleUnit = {
       val limit = Price(solver.solve(100, F, 0, 1, AllowedSolution.BELOW_SIDE))
-      PersistentLimitBidOrder(issuer, limit, System.currentTimeMillis(), tradable, UUID.randomUUID())
+      PersistentLimitBidOrder(issuer, limit, tradable, UUID.randomUUID())
     }
 
     /** Buyer's equilibrium limit price should equate its reservation value with a seller's virtual reservation value. */
@@ -145,7 +145,7 @@ object BuyersBidDoubleAuctionSimulation extends App {
 
     def apply(tradable: Tradable): PersistentLimitAskOrder with SingleUnit = {
       val limit = Price(reservationValue)
-      PersistentLimitAskOrder(issuer, limit, System.currentTimeMillis(), tradable, UUID.randomUUID())
+      PersistentLimitAskOrder(issuer, limit, tradable, UUID.randomUUID())
     }
 
   }

--- a/src/functional/scala/org/economicsl/agora/markets/auctions/mutable/continuous/KDoubleAuctionSimulation.scala
+++ b/src/functional/scala/org/economicsl/agora/markets/auctions/mutable/continuous/KDoubleAuctionSimulation.scala
@@ -141,7 +141,7 @@ object KDoubleAuctionSimulation extends App {
 
     def apply(tradable: Tradable): PersistentLimitBidOrder with SingleUnit = {
       val limit = Price((reservationValue + c * k) / (1 + k))
-      PersistentLimitBidOrder(issuer, limit, System.currentTimeMillis(), tradable, UUID.randomUUID())
+      PersistentLimitBidOrder(issuer, limit, tradable, UUID.randomUUID())
     }
 
     private[this] val c = 0.5 * (1 - k)
@@ -167,7 +167,7 @@ object KDoubleAuctionSimulation extends App {
 
     def apply(tradable: Tradable): PersistentLimitAskOrder with SingleUnit = {
       val limit = Price(c + (d * reservationValue) / (1 + k))
-      PersistentLimitAskOrder(issuer, limit, System.currentTimeMillis(), tradable, UUID.randomUUID())
+      PersistentLimitAskOrder(issuer, limit, tradable, UUID.randomUUID())
     }
 
     private[this] val c = 0.5 * (1 - k)

--- a/src/functional/scala/org/economicsl/agora/markets/auctions/mutable/continuous/SellersAskDoubleAuctionSimulation.scala
+++ b/src/functional/scala/org/economicsl/agora/markets/auctions/mutable/continuous/SellersAskDoubleAuctionSimulation.scala
@@ -112,7 +112,7 @@ object SellersAskDoubleAuctionSimulation extends App {
 
     def apply(tradable: Tradable): PersistentLimitBidOrder with SingleUnit = {
       val limit = Price(reservationValue)
-      PersistentLimitBidOrder(issuer, limit, System.currentTimeMillis(), tradable, UUID.randomUUID())
+      PersistentLimitBidOrder(issuer, limit, tradable, UUID.randomUUID())
     }
 
   }
@@ -134,7 +134,7 @@ object SellersAskDoubleAuctionSimulation extends App {
 
     def apply(tradable: Tradable): PersistentLimitAskOrder with SingleUnit = {
       val limit = Price(solver.solve(100, F, 0, 1, AllowedSolution.BELOW_SIDE))
-      PersistentLimitAskOrder(issuer, limit, System.currentTimeMillis(), tradable, UUID.randomUUID())
+      PersistentLimitAskOrder(issuer, limit, tradable, UUID.randomUUID())
     }
 
     /** Seller's equilibrium limit price should equate its reservation value with a buyer's virtual reservation value. */

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/Order.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/Order.scala
@@ -24,16 +24,6 @@ trait Order extends Tradable {
 
   def issuer: UUID
 
-  def timestamp: Long
-
   def tradable: Tradable
-
-}
-
-
-object Order {
-
-  /** By default, instances of `Order` are ordered based on `timestamp` from lowest to highest */
-  implicit def ordering[O <: Order]: Ordering[O] = Ordering.by(order => (order.timestamp, order.uuid))
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/LimitAskOrder.scala
@@ -56,7 +56,6 @@ object LimitAskOrder {
     * @param issuer the `UUID` of the actor that issued the `LimitAskOrder`.
     * @param limit the minimum price at which the `LimitAskOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `LimitAskOrder` was issued.
-    * @param timestamp the time at which the `LimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitAskOrder` was issued.
     * @param uuid the `UUID` of the `LimitAskOrder`.
     * @return an instance of a `LimitAskOrder`.
@@ -64,15 +63,14 @@ object LimitAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentLimitAskOrder`.
     */
-  def apply(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): LimitAskOrder with MultiUnit = {
-    MultiUnitImpl(issuer, limit, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID): LimitAskOrder with MultiUnit = {
+    MultiUnitImpl(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `LimitAskOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `LimitAskOrder`.
     * @param limit the minimum price at which the `LimitAskOrder` can be executed.
-    * @param timestamp the time at which the `LimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitAskOrder` was issued.
     * @param uuid the `UUID` of the `LimitAskOrder`.
     * @return an instance of a `LimitAskOrder`.
@@ -80,8 +78,8 @@ object LimitAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentLimitAskOrder`.
     */
-  def apply(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable, uuid: UUID): LimitAskOrder with SingleUnit = {
-    SingleUnitImpl(issuer, limit, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID): LimitAskOrder with SingleUnit = {
+    SingleUnitImpl(issuer, limit, tradable, uuid)
   }
 
   /** Class providing a default implementation of a `LimitAskOrder` suitable for use in securities market simulations.
@@ -89,7 +87,6 @@ object LimitAskOrder {
     * @param issuer the `UUID` of the actor that issued the `LimitAskOrder`.
     * @param limit the minimum price at which the `LimitAskOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `LimitAskOrder` was issued.
-    * @param timestamp the time at which the `LimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitAskOrder` was issued.
     * @param uuid the `UUID` of the `LimitAskOrder`.
     * @return an instance of a `LimitAskOrder`.
@@ -97,14 +94,13 @@ object LimitAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentLimitAskOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID)
     extends LimitAskOrder with MultiUnit
 
   /** Class providing a default implementation of a `LimitAskOrder` suitable for use in securities market simulations.
     *
     * @param issuer the `UUID` of the actor that issued the `LimitAskOrder`.
     * @param limit the minimum price at which the `LimitAskOrder` can be executed.
-    * @param timestamp the time at which the `LimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitAskOrder` was issued.
     * @param uuid the `UUID` of the `LimitAskOrder`.
     * @return an instance of a `LimitAskOrder`.
@@ -112,7 +108,7 @@ object LimitAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentLimitAskOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID)
     extends LimitAskOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/MarketAskOrder.scala
@@ -22,7 +22,7 @@ import org.economicsl.agora.markets.tradables.orders.Persistent
 
 
 /** Trait defining a `MarketAskOrder`. */
-trait MarketAskOrder extends LimitAskOrder with Persistent {
+trait MarketAskOrder extends LimitAskOrder {
   this: Quantity =>
 
   /** An issuer of a `MarketAskOrder` is willing to sell for any positive `Price`. */
@@ -41,7 +41,6 @@ object MarketAskOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
     * @param quantity the number of units of the `tradable` for which the `MarketAskOrder` was issued.
-    * @param timestamp the time at which the `MarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
     * @param uuid the `UUID` of the `MarketAskOrder`.
     * @return an instance of a `MarketAskOrder`.
@@ -49,14 +48,13 @@ object MarketAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentMarketAskOrder`.
     */
-  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): MarketAskOrder with MultiUnit = {
-    MultiUnitImpl(issuer, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID): MarketAskOrder with MultiUnit = {
+    MultiUnitImpl(issuer, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `MarketAskOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
-    * @param timestamp the time at which the `MarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
     * @param uuid the `UUID` of the `MarketAskOrder`.
     * @return an instance of a `MarketAskOrder`.
@@ -64,8 +62,8 @@ object MarketAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentMarketAskOrder`.
     */
-  def apply(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID): MarketAskOrder with SingleUnit = {
-    SingleUnitImpl(issuer, timestamp, tradable, uuid)
+  def apply(issuer: UUID, tradable: Tradable, uuid: UUID): MarketAskOrder with SingleUnit = {
+    SingleUnitImpl(issuer, tradable, uuid)
   }
 
 
@@ -73,7 +71,6 @@ object MarketAskOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
     * @param quantity the number of units of the `tradable` for which the `MarketAskOrder` was issued.
-    * @param timestamp the time at which the `MarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
     * @param uuid the `UUID` of the `MarketAskOrder`.
     * @return an instance of a `MarketAskOrder`.
@@ -81,14 +78,13 @@ object MarketAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentMarketAskOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID)
     extends MarketAskOrder with MultiUnit
 
 
   /** Class providing a default implementation of a `MarketAskOrder` designed for use in securities market simulations.
     *
     * @param issuer the `UUID` of the actor that issued the `MarketAskOrder`.
-    * @param timestamp the time at which the `MarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketAskOrder` was issued.
     * @param uuid the `UUID` of the `MarketAskOrder`.
     * @return an instance of a `MarketAskOrder`.
@@ -96,7 +92,7 @@ object MarketAskOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketAskOrder` to persist in an
     *       `AskOrderBook` use a `PersistentMarketAskOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, tradable: Tradable, uuid: UUID)
     extends MarketAskOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentLimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentLimitAskOrder.scala
@@ -38,26 +38,24 @@ object PersistentLimitAskOrder {
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitAskOrder`.
     * @param limit the minimum price at which the `PersistentLimitAskOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `PersistentLimitAskOrder` was issued.
-    * @param timestamp the time at which the `PersistentLimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitAskOrder`.
     * @return an instance of a `PersistentLimitAskOrder`.
     */
-  def apply(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentLimitAskOrder with MultiUnit = {
-    MultiUnitImpl(issuer, limit, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID): PersistentLimitAskOrder with MultiUnit = {
+    MultiUnitImpl(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `PersistentLimitAskOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitAskOrder`.
     * @param limit the minimum price at which the `PersistentLimitAskOrder` can be executed.
-    * @param timestamp the time at which the `PersistentLimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitAskOrder`.
     * @return an instance of a `PersistentLimitAskOrder`.
     */
-  def apply(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentLimitAskOrder with SingleUnit = {
-    SingleUnitImpl(issuer, limit, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID): PersistentLimitAskOrder with SingleUnit = {
+    SingleUnitImpl(issuer, limit, tradable, uuid)
   }
 
   /** Class providing a default implementation of a `PersistentLimitAskOrder` suitable for use in securities market simulations.
@@ -65,13 +63,11 @@ object PersistentLimitAskOrder {
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitAskOrder`.
     * @param limit the minimum price at which the `PersistentLimitAskOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `PersistentLimitAskOrder` was issued.
-    * @param timestamp the time at which the `PersistentLimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitAskOrder`.
     * @return an instance of a `PersistentLimitAskOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable,
-                                         uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID)
     extends PersistentLimitAskOrder with MultiUnit
 
 
@@ -79,13 +75,11 @@ object PersistentLimitAskOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitAskOrder`.
     * @param limit the minimum price at which the `PersistentLimitAskOrder` can be executed.
-    * @param timestamp the time at which the `PersistentLimitAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitAskOrder`.
     * @return an instance of a `PersistentLimitAskOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable,
-                                          uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID)
     extends PersistentLimitAskOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentMarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/ask/PersistentMarketAskOrder.scala
@@ -37,25 +37,23 @@ object PersistentMarketAskOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketAskOrder`.
     * @param quantity the number of units of the `tradable` for which the `PersistentMarketAskOrder` was issued.
-    * @param timestamp the time at which the `PersistentMarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketAskOrder`.
     * @return an instance of a `PersistentMarketAskOrder`.
     */
-  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentMarketAskOrder with MultiUnit = {
-    MultiUnitImpl(issuer, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID): PersistentMarketAskOrder with MultiUnit = {
+    MultiUnitImpl(issuer, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `PersistentMarketAskOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketAskOrder`.
-    * @param timestamp the time at which the `PersistentMarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketAskOrder`.
     * @return an instance of a `PersistentMarketAskOrder`.
     */
-  def apply(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentMarketAskOrder with SingleUnit = {
-    SingleUnitImpl(issuer, timestamp, tradable, uuid)
+  def apply(issuer: UUID, tradable: Tradable, uuid: UUID): PersistentMarketAskOrder with SingleUnit = {
+    SingleUnitImpl(issuer, tradable, uuid)
   }
 
 
@@ -63,24 +61,22 @@ object PersistentMarketAskOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketAskOrder`.
     * @param quantity the number of units of the `tradable` for which the `PersistentMarketAskOrder` was issued.
-    * @param timestamp the time at which the `PersistentMarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketAskOrder`.
     * @return an instance of a `PersistentMarketAskOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID)
     extends PersistentMarketAskOrder with MultiUnit
 
 
   /** Class providing a default implementation of a `PersistentMarketAskOrder` designed for use in securities market simulations.
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketAskOrder`.
-    * @param timestamp the time at which the `PersistentMarketAskOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketAskOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketAskOrder`.
     * @return an instance of a `PersistentMarketAskOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, tradable: Tradable, uuid: UUID)
     extends PersistentMarketAskOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/LimitBidOrder.scala
@@ -57,7 +57,6 @@ object LimitBidOrder {
     * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
     * @param limit the minimum price at which the `LimitBidOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `LimitBidOrder` was issued.
-    * @param timestamp the time at which the `LimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
     * @param uuid the `UUID` of the `LimitBidOrder`.
     * @return an instance of a `LimitBidOrder`.
@@ -65,15 +64,14 @@ object LimitBidOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentLimitBidOrder`.
     */
-  def apply(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): LimitBidOrder with MultiUnit = {
-    MultiUnitImpl(issuer, limit, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID): LimitBidOrder with MultiUnit = {
+    MultiUnitImpl(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `LimitBidOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
     * @param limit the minimum price at which the `LimitBidOrder` can be executed.
-    * @param timestamp the time at which the `LimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
     * @param uuid the `UUID` of the `LimitBidOrder`.
     * @return an instance of a `LimitBidOrder`.
@@ -81,8 +79,8 @@ object LimitBidOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentLimitBidOrder`.
     */
-  def apply(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable, uuid: UUID): LimitBidOrder with SingleUnit = {
-    SingleUnitImpl(issuer, limit, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID): LimitBidOrder with SingleUnit = {
+    SingleUnitImpl(issuer, limit, tradable, uuid)
   }
 
 
@@ -91,15 +89,13 @@ object LimitBidOrder {
     * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
     * @param limit the minimum price at which the `LimitBidOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `LimitBidOrder` was issued.
-    * @param timestamp the time at which the `LimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
     * @param uuid the `UUID` of the `LimitBidOrder`.
     * @note this `LimitBidOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `LimitBidOrder` must be filled
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentLimitBidOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable,
-                                         uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID)
     extends LimitBidOrder with MultiUnit
 
 
@@ -107,15 +103,13 @@ object LimitBidOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `LimitBidOrder`.
     * @param limit the minimum price at which the `LimitBidOrder` can be executed.
-    * @param timestamp the time at which the `LimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `LimitBidOrder` was issued.
     * @param uuid the `UUID` of the `LimitBidOrder`.
     * @note this `LimitBidOrder` is an "Immediate-Or-Cancel (IOC)" order meaning that a `LimitBidOrder` must be filled
     *       (either partially or fully) immediately or be cancelled. If you want a `LimitBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentLimitBidOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable,
-                                          uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID)
     extends LimitBidOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/MarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/MarketBidOrder.scala
@@ -41,7 +41,6 @@ object MarketBidOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
     * @param quantity the number of units of the `tradable` for which the `MarketBidOrder` was issued.
-    * @param timestamp the time at which the `MarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
     * @param uuid the `UUID` of the `MarketBidOrder`.
     * @return an instance of a `MarketBidOrder`.
@@ -49,14 +48,13 @@ object MarketBidOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentMarketBidOrder`.
     */
-  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): MarketBidOrder with MultiUnit = {
-    MultiUnitImpl(issuer, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID): MarketBidOrder with MultiUnit = {
+    MultiUnitImpl(issuer, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `MarketBidOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
-    * @param timestamp the time at which the `MarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
     * @param uuid the `UUID` of the `MarketBidOrder`.
     * @return an instance of a `MarketBidOrder`.
@@ -64,15 +62,14 @@ object MarketBidOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentMarketBidOrder`.
     */
-  def apply(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID): MarketBidOrder with SingleUnit = {
-    SingleUnitImpl(issuer, timestamp, tradable, uuid)
+  def apply(issuer: UUID, tradable: Tradable, uuid: UUID): MarketBidOrder with SingleUnit = {
+    SingleUnitImpl(issuer, tradable, uuid)
   }
 
   /** Class providing a default implementation of a `MarketBidOrder` designed for use in securities market simulations.
     *
     * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
     * @param quantity the number of units of the `tradable` for which the `MarketBidOrder` was issued.
-    * @param timestamp the time at which the `MarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
     * @param uuid the `UUID` of the `MarketBidOrder`.
     * @return an instance of a `MarketBidOrder`.
@@ -80,14 +77,13 @@ object MarketBidOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentMarketBidOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID)
     extends MarketBidOrder with MultiUnit
 
 
   /** Class providing a default implementation of a `MarketBidOrder` designed for use in securities market simulations.
     *
     * @param issuer the `UUID` of the actor that issued the `MarketBidOrder`.
-    * @param timestamp the time at which the `MarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `MarketBidOrder` was issued.
     * @param uuid the `UUID` of the `MarketBidOrder`.
     * @return an instance of a `MarketBidOrder`.
@@ -95,7 +91,7 @@ object MarketBidOrder {
     *       (either partially or fully) immediately or be cancelled. If you want a `MarketBidOrder` to persist in an
     *       `BidOrderBook` use a `PersistentMarketBidOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, tradable: Tradable, uuid: UUID)
     extends MarketBidOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentLimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentLimitBidOrder.scala
@@ -38,26 +38,24 @@ object PersistentLimitBidOrder {
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitBidOrder`.
     * @param limit the minimum price at which the `PersistentLimitBidOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `PersistentLimitBidOrder` was issued.
-    * @param timestamp the time at which the `PersistentLimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitBidOrder`.
     * @return an instance of a `PersistentLimitBidOrder`.
     */
-  def apply(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentLimitBidOrder with MultiUnit = {
-    MultiUnitImpl(issuer, limit, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID): PersistentLimitBidOrder with MultiUnit = {
+    MultiUnitImpl(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `PersistentLimitBidOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitBidOrder`.
     * @param limit the minimum price at which the `PersistentLimitBidOrder` can be executed.
-    * @param timestamp the time at which the `PersistentLimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitBidOrder`.
     * @return an instance of a `PersistentLimitBidOrder`.
     */
-  def apply(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentLimitBidOrder with SingleUnit = {
-    SingleUnitImpl(issuer, limit, timestamp, tradable, uuid)
+  def apply(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID): PersistentLimitBidOrder with SingleUnit = {
+    SingleUnitImpl(issuer, limit, tradable, uuid)
   }
 
 
@@ -66,11 +64,10 @@ object PersistentLimitBidOrder {
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitBidOrder`.
     * @param limit the minimum price at which the `PersistentLimitBidOrder` can be executed.
     * @param quantity the number of units of the `tradable` for which the `PersistentLimitBidOrder` was issued.
-    * @param timestamp the time at which the `PersistentLimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitBidOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, limit: Price, quantity: Long, tradable: Tradable, uuid: UUID)
     extends PersistentLimitBidOrder with MultiUnit
 
 
@@ -78,11 +75,10 @@ object PersistentLimitBidOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentLimitBidOrder`.
     * @param limit the minimum price at which the `PersistentLimitBidOrder` can be executed.
-    * @param timestamp the time at which the `PersistentLimitBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentLimitBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentLimitBidOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, limit: Price, tradable: Tradable, uuid: UUID)
     extends PersistentLimitBidOrder with SingleUnit
 
 }

--- a/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentMarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/agora/markets/tradables/orders/bid/PersistentMarketBidOrder.scala
@@ -37,25 +37,23 @@ object PersistentMarketBidOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketBidOrder`.
     * @param quantity the number of units of the `tradable` for which the `PersistentMarketBidOrder` was issued.
-    * @param timestamp the time at which the `PersistentMarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketBidOrder`.
     * @return an instance of a `PersistentMarketBidOrder`.
     */
-  def apply(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentMarketBidOrder with MultiUnit = {
-    MultiUnitImpl(issuer, quantity, timestamp, tradable, uuid)
+  def apply(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID): PersistentMarketBidOrder with MultiUnit = {
+    MultiUnitImpl(issuer, quantity, tradable, uuid)
   }
 
   /** Creates an instance of a `PersistentMarketBidOrder`.
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketBidOrder`.
-    * @param timestamp the time at which the `PersistentMarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketBidOrder`.
     * @return an instance of a `PersistentMarketBidOrder`.
     */
-  def apply(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID): PersistentMarketBidOrder with SingleUnit = {
-    SingleUnitImpl(issuer, timestamp, tradable, uuid)
+  def apply(issuer: UUID, tradable: Tradable, uuid: UUID): PersistentMarketBidOrder with SingleUnit = {
+    SingleUnitImpl(issuer, tradable, uuid)
   }
 
 
@@ -63,24 +61,22 @@ object PersistentMarketBidOrder {
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketBidOrder`.
     * @param quantity the number of units of the `tradable` for which the `PersistentMarketBidOrder` was issued.
-    * @param timestamp the time at which the `PersistentMarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketBidOrder`.
     * @return an instance of a `PersistentMarketBidOrder`.
     */
-  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class MultiUnitImpl(issuer: UUID, quantity: Long, tradable: Tradable, uuid: UUID)
     extends PersistentMarketBidOrder with MultiUnit
 
 
   /** Class providing a default implementation of a `PersistentMarketBidOrder` designed for use in securities market simulations.
     *
     * @param issuer the `UUID` of the actor that issued the `PersistentMarketBidOrder`.
-    * @param timestamp the time at which the `PersistentMarketBidOrder` was issued.
     * @param tradable the `Tradable` for which the `PersistentMarketBidOrder` was issued.
     * @param uuid the `UUID` of the `PersistentMarketBidOrder`.
     * @return an instance of a `PersistentMarketBidOrder`.
     */
-  private[this] case class SingleUnitImpl(issuer: UUID, timestamp: Long, tradable: Tradable, uuid: UUID)
+  private[this] case class SingleUnitImpl(issuer: UUID, tradable: Tradable, uuid: UUID)
     extends PersistentMarketBidOrder with SingleUnit
 
 }

--- a/src/performance/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookMicroBenchmark.scala
+++ b/src/performance/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookMicroBenchmark.scala
@@ -29,7 +29,7 @@ object SortedOrderBookMicroBenchmark extends Bench.OnlineRegressionReport with O
 
   /** Generates a collection of `SortedOrderBook` instances of increasing size. */
   val orderBooks = for { size <- sizes } yield {
-    val orderBook = SortedOrderBook[AskOrder with Persistent](validTradable)
+    val orderBook = SortedOrderBook[LimitAskOrder with Persistent](validTradable)
     val orders = for { i <- 1 to size } yield orderGenerator.nextAskOrder(0.5, validTradable)
     orders.foreach( order => orderBook.add(order) )
     orderBook

--- a/src/test/scala/org/economicsl/agora/RandomOrderGenerator.scala
+++ b/src/test/scala/org/economicsl/agora/RandomOrderGenerator.scala
@@ -17,8 +17,8 @@ package org.economicsl.agora
 
 import java.util.UUID
 
-import org.economicsl.agora.markets.tradables.orders.ask.{AskOrder, PersistentLimitAskOrder, PersistentMarketAskOrder}
-import org.economicsl.agora.markets.tradables.orders.bid.{BidOrder, PersistentLimitBidOrder, PersistentMarketBidOrder}
+import org.economicsl.agora.markets.tradables.orders.ask.{AskOrder, LimitAskOrder, PersistentLimitAskOrder, PersistentMarketAskOrder}
+import org.economicsl.agora.markets.tradables.orders.bid.{BidOrder, LimitBidOrder, PersistentLimitBidOrder, PersistentMarketBidOrder}
 import org.economicsl.agora.markets.tradables.{Price, Quantity, Tradable}
 import org.apache.commons.math3.{distribution, random}
 import org.economicsl.agora.markets.tradables.orders.Persistent
@@ -47,7 +47,7 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     * @param tradable the particular `Tradable` for which the order should be generated.
     * @return an instance of a `LimitAskOrder`.
     */
-  def nextAskOrder(marketOrderProbability: Double, tradable: Tradable): AskOrder with Persistent with Quantity = {
+  def nextAskOrder(marketOrderProbability: Double, tradable: Tradable): LimitAskOrder with Persistent with Quantity = {
     if (prng.nextDouble() < marketOrderProbability) {
       nextLimitAskOrder(tradable)
     } else {
@@ -61,7 +61,7 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     * @param tradable the particular `Tradable` for which the order should be generated.
     * @return an instance of a `LimitBidOrder`.
     */
-  def nextBidOrder(marketOrderProbability: Double, tradable: Tradable): BidOrder with Persistent with Quantity = {
+  def nextBidOrder(marketOrderProbability: Double, tradable: Tradable): LimitBidOrder with Persistent with Quantity = {
     if (prng.nextDouble() < marketOrderProbability) {
       nextLimitBidOrder(tradable)
     } else {
@@ -76,8 +76,8 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     * @return an instance of a `LimitAskOrder`.
     */
   def nextLimitAskOrder(limit: Price, tradable: Tradable): PersistentLimitAskOrder with Quantity = {
-    val (issuer, quantity, timestamp, uuid) = (nextIssuer(), nextQuantity(askQuantityDistribution), nextTimestamp(), nextUUID())
-    PersistentLimitAskOrder(issuer, limit, quantity, timestamp, tradable, uuid)
+    val (issuer, quantity, uuid) = (nextIssuer(), nextQuantity(askQuantityDistribution), nextUUID())
+    PersistentLimitAskOrder(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Generates a random `LimitAskOrder` for a particular `Tradable`.
@@ -87,8 +87,8 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     */
   def nextLimitAskOrder(tradable: Tradable): PersistentLimitAskOrder with Quantity = {
     val (limit, quantity) = (nextPrice(askPriceDistribution), nextQuantity(askQuantityDistribution))
-    val (issuer, timestamp, uuid) = (nextIssuer(), nextTimestamp(), nextUUID())
-    PersistentLimitAskOrder(issuer, limit, quantity, timestamp, tradable, uuid)
+    val (issuer, uuid) = (nextIssuer(), nextUUID())
+    PersistentLimitAskOrder(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Generates a random `LimitBidOrder` for a particular `Tradable`.
@@ -98,8 +98,8 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     * @return an instance of a `LimitBidOrder`.
     */
   def nextLimitBidOrder(limit: Price, tradable: Tradable): PersistentLimitBidOrder with Quantity = {
-    val (issuer, quantity, timestamp, uuid) = (nextIssuer(), nextQuantity(bidQuantityDistribution), nextTimestamp(), nextUUID())
-    PersistentLimitBidOrder(issuer, limit, quantity, timestamp, tradable, uuid)
+    val (issuer, quantity, uuid) = (nextIssuer(), nextQuantity(bidQuantityDistribution), nextUUID())
+    PersistentLimitBidOrder(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Generates a random `LimitBidOrder` for a particular `Tradable`.
@@ -109,8 +109,8 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     */
   def nextLimitBidOrder(tradable: Tradable): PersistentLimitBidOrder with Quantity = {
     val (limit, quantity) = (nextPrice(bidPriceDistribution), nextQuantity(bidQuantityDistribution))
-    val (issuer, timestamp, uuid) = (nextIssuer(), nextTimestamp(), nextUUID())
-    PersistentLimitBidOrder(issuer, limit, quantity, timestamp, tradable, uuid)
+    val (issuer, uuid) = (nextIssuer(), nextUUID())
+    PersistentLimitBidOrder(issuer, limit, quantity, tradable, uuid)
   }
 
   /** Generates a either a random `LimitAskOrder` or a `LimitBidOrder` for a particular `Tradable`.
@@ -133,8 +133,8 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     * @return an instance of a `MarketAskOrder`.
     */
   def nextMarketAskOrder(tradable: Tradable): PersistentMarketAskOrder with Quantity = {
-    val (issuer, quantity, timestamp, uuid) = (nextIssuer(), nextQuantity(askQuantityDistribution), nextTimestamp(), nextUUID())
-    PersistentMarketAskOrder(issuer, quantity, timestamp, tradable, uuid)
+    val (issuer, quantity, uuid) = (nextIssuer(), nextQuantity(askQuantityDistribution), nextUUID())
+    PersistentMarketAskOrder(issuer, quantity, tradable, uuid)
   }
 
   /** Generates a random `MarketBidOrder` for a particular `Tradable`.
@@ -143,8 +143,8 @@ class RandomOrderGenerator(val prng: random.RandomGenerator,
     * @return an instance of a `MarketBidOrder`.
     */
   def nextMarketBidOrder(tradable: Tradable): PersistentMarketBidOrder with Quantity = {
-    val (issuer, quantity, timestamp, uuid) = (nextIssuer(), nextQuantity(bidQuantityDistribution), nextTimestamp(), nextUUID())
-    PersistentMarketBidOrder(issuer, quantity, timestamp, tradable, uuid)
+    val (issuer, quantity, uuid) = (nextIssuer(), nextQuantity(bidQuantityDistribution), nextUUID())
+    PersistentMarketBidOrder(issuer, quantity, tradable, uuid)
   }
 
 }
@@ -193,12 +193,6 @@ object RandomOrderGenerator {
     * @return a `UUID`.
     */
   def nextUUID(): UUID = UUID.randomUUID()
-
-  /** Generates a timestamp.
-    *
-    * @return the current system time in milliseconds.
-    */
-  def nextTimestamp(): Long = System.currentTimeMillis()
 
   /** Generates a random limit price.
     *


### PR DESCRIPTION
as discussed with @prauwolf et al yesterday, I am removing the timestamp from the order trait and instead will have the market timestamp an order as it is received but before it is passed into the auction mechanism...