### PR TITLE
Single order restriction

### DIFF
--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/continuous/PostedPriceAuction.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/continuous/PostedPriceAuction.scala
@@ -33,13 +33,13 @@ import org.economicsl.agora.markets.tradables.orders.{Order, Persistent}
 class PostedPriceAuction[O1 <: Order with LimitPrice with Quantity, OB <: orderbooks.OrderBook[O2], O2 <: Order with LimitPrice with Persistent with Quantity]
                         (orderBook: OB, matchingRule: (O1, OB) => Option[O2], pricingRule: (O1, O2) => Price) {
 
-  final def cancel(order: O2): Option[O2] = orderBook.remove(order.uuid)
+  final def cancel(order: O2): Option[O2] = orderBook.remove(order.issuer)
 
   final def clear(): Unit = orderBook.clear()
 
   final def fill(order: O1): Option[Fill] = {
     val matchingOrders = matchingRule(order, orderBook) // eventually this will return an iterable!
-    matchingOrders.foreach(matchingOrder => orderBook.remove(matchingOrder.uuid)) // SIDE EFFECT!
+    matchingOrders.foreach(matchingOrder => orderBook.remove(matchingOrder.issuer)) // SIDE EFFECT!
     matchingOrders.map { matchingOrder =>
       val price = pricingRule(order, matchingOrder)
       val quantity = math.min(order.quantity, matchingOrder.quantity) // not dealing with residual orders!

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/ExistingOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/ExistingOrders.scala
@@ -35,10 +35,14 @@ trait ExistingOrders[O <: Order with Persistent] {
   /** Add an new `Order` to the `OrderBook`.
     *
     * @param order the `Order` that should be added to the `OrderBook`.
+    * @note Following the design of the University of Michigan Auction Bot, an `issuer` can have only one active order
+    *       at a time: a new order added to the `OrderBook` supersedes any existing order with the same issuer. This
+    *       requirement is not a restriction per se as the general definition of an `Order` allows an agent to
+    *       potentially specify any arbitrary function.
     */
   def add(order: O): Unit = {
     require(order.tradable == tradable)
-    existingOrders += (order.uuid -> order)
+    existingOrders += (order.issuer -> order)
   }
 
   /** Remove all `Order` instances from the `OrderBook`. */

--- a/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrders.scala
+++ b/src/main/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrders.scala
@@ -29,14 +29,17 @@ import scala.collection.mutable
 trait SortedOrders[O <: Order with Persistent] {
   this: OrderBookLike[O] with ExistingOrders[O] =>
 
-  /** Add an `Order` to the `SortedOrderBook`.
+  /** Add an new `Order` to the `OrderBook`.
     *
-    * @param order the `Order` that should be added to the `SortedOrderBook`.
-    * @note adding an `Order` to the `SortedOrderBook` is an `O(log n)` operation.
+    * @param order the `Order` that should be added to the `OrderBook`.
+    * @note Following the design of the University of Michigan Auction Bot, an `issuer` can have only one active order
+    *       at a time: a new order added to the `OrderBook` supersedes any existing order with the same issuer. This
+    *       requirement is not a restriction per se as the general definition of an `Order` allows an agent to
+    *       potentially specify any arbitrary function.
     */
   override def add(order: O): Unit = {
     require(order.tradable == tradable)
-    existingOrders += (order.uuid -> order); sortedOrders.add(order)
+    existingOrders += (order.issuer -> order); sortedOrders.add(order)
   }
 
   /** Remove all existing `Order` instances from the `OrderBook`. */

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/OrderBookSpec.scala
@@ -98,7 +98,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitAskOrder with
       val order = orderGenerator.nextLimitAskOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
-      val removedOrder = orderBook.remove(order.uuid)
+      val removedOrder = orderBook.remove(order.issuer)
       removedOrder should be(Some(order))
       orderBook.headOption should be(None)
     }
@@ -106,7 +106,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitAskOrder with
     scenario(s"Removing an ask order from an empty mutable.OrderBook.") {
       val order = orderGenerator.nextLimitAskOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
-      val removedOrder = orderBook.remove(order.uuid)  // note that order has not been added!
+      val removedOrder = orderBook.remove(order.issuer)  // note that order has not been added!
       removedOrder should be(None)
       orderBook.headOption should be(None)
     }

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/SortedOrderBookSpec.scala
@@ -73,7 +73,6 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       orderBook.add(order)
       orderBook.headOption should be(Some(order))
-      orderBook.existingOrders.headOption should be(Some((order.uuid, order)))
     }
 
     scenario(s"Adding an invalid bid order to a mutable SortedOrderBook.") {
@@ -113,7 +112,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
-      val removedOrder = orderBook.remove(order.uuid)
+      val removedOrder = orderBook.remove(order.issuer)
       removedOrder should be(Some(order))
       orderBook.headOption should be(None)
       orderBook.existingOrders.headOption should be(None)
@@ -122,7 +121,7 @@ class SortedOrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrde
     scenario(s"Removing a bid order from an empty mutable SortedOrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
-      val removedOrder = orderBook.remove(order.uuid)  // note that order has not been added!
+      val removedOrder = orderBook.remove(order.issuer)  // note that order has not been added!
       removedOrder should be(None)
       orderBook.headOption should be(None)
       orderBook.existingOrders.headOption should be(None)

--- a/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/agora/markets/auctions/mutable/orderbooks/parallel/OrderBookSpec.scala
@@ -118,7 +118,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
       orderBook.add(order)
-      val removedOrder = orderBook.remove(order.uuid)
+      val removedOrder = orderBook.remove(order.issuer)
       removedOrder should be(Some(order))
       orderBook.headOption should be(None)
     }
@@ -126,7 +126,7 @@ class OrderBookSpec extends auctions.orderbooks.OrderBookSpec[LimitBidOrder with
     scenario(s"Removing a bid order from an empty parallel, mutable OrderBook.") {
       val order = orderGenerator.nextLimitBidOrder(validTradable)
       val orderBook = orderBookFactory(validTradable)
-      val removedOrder = orderBook.remove(order.uuid)  // note that order has not been added!
+      val removedOrder = orderBook.remove(order.issuer)  // note that order has not been added!
       removedOrder should be(None)
       orderBook.headOption should be(None)
     }


### PR DESCRIPTION
per yesterday's discussion with @prauwolf et all, I am imposing the constraint that an issuer can have only a single active ask and bid order in an order book.  Any additional persistent orders placed in an order book will over-write the existing orders...